### PR TITLE
Add Ideal Sun Sensor Model and MATLAB Sun Vector Determination Algorithm

### DIFF
--- a/MATLAB/README.md
+++ b/MATLAB/README.md
@@ -3,7 +3,7 @@ Started by Kyle Krol on Sep 4, 2019
 
 **Authors** Nathan Zimmerberg, Kyle Krol
 
-Latest Revision: Oct 19, 2019
+Latest Revision: Oct 27, 2019
 
 Pathfinder for Autonomous Navigation
 
@@ -83,8 +83,10 @@ Each satellites state has the following members and submembers:
  * `sensors`
    * `gyro_bias`, (rad/s)
    * `magnetometer_bias`, (T)
-   * `sunsensor_real_normals`, (V)
-   * `sunsensor_measured_normals`, (V)
+   * `sunsensor_real_normals`, (unitless)
+   * `sunsensor_real_voltage_maximums`, normalization constants for voltage measurements (V)
+   * `sunsensor_measured_normals`, (unitless)
+   * `sunsensor_measured_voltage_maximums`, (V)
    * `gps_bias`,  (m and m/s)
    * `gps_time_till_lock`,
        time till the GPS gets a lock, starts at `const.GPS_LOCK_TIME`, then counts down and stays at 0
@@ -291,7 +293,7 @@ One the Matlab simulation side, next getting a complete version of `sensor_readi
 | dynamics_update              | Nathan  |          | wip                  | not started | NA          |
 | sensors_update               |         |          | not started          | not started | NA          |
 | get_next_maneuver            |         |          | not started          | not started | not started |
-| orbit_propagator             |         |          | not started          | not started | not started |
+| orbit_propagator             | Kyle    |          | wip                  | wip         | wip         |
 | estimate_orbits              |         |          | not started          | not started | not started |
 | adcs_update                  | Nathan  |          | wip                  | not started | not started |
 | env_atmosphere_density       | Sruti   |          | not started          | not started | NA          |
@@ -300,11 +302,12 @@ One the Matlab simulation side, next getting a complete version of `sensor_readi
 | env_gravity                  |         |          | wip                  | not started | NA          |
 | env_magnetic_field           | Nathan  |          | wip                  | done        | wip         |
 | env_sun_vector               | Nathan  |          | done                 | done        | wip         |
-| utl_rotateframe              | Kyle    |          | done                 | done        | wip         |
-| utl_quat_conj                | Kyle    |          | done                 | done        | wip         |
-| utl_dcm2quat                 | Kyle    |          | done                 | done        | wip         |
-| utl_quat_cross_mult          | Kyle    |          | done                 | done        | wip         |
-| utl_triad                    | Kyle    |          | done                 | done        | wip         |
+| utl_rotateframe              | Kyle    |          | done                 | done        | done        |
+| utl_quat_conj                | Kyle    |          | done                 | done        | done        |
+| utl_dcm2quat                 | Kyle    |          | done                 | done        | done        |
+| utl_quat_cross_mult          | Kyle    |          | done                 | done        | done        |
+| utl_triad                    | Kyle    |          | done                 | done        | done        |
+| utl_vect_rot2quat            | Kyle    |          | done                 | done        | done        |
 | utl_compare_main_states      |         |          | not started          | not started | NA          |
 | utl_compare_dynamics         |         |          | not started          | not started | NA          |
 | utl_compare_actuators        |         |          | not started          | not started | NA          |

--- a/MATLAB/initialize_main_state.m
+++ b/MATLAB/initialize_main_state.m
@@ -87,6 +87,8 @@ sensors.sunsensor_real_normals= transpose([ 0.9397	0.3420      0
                                     -0.3420	0           0.9397
                                     0       0.3420      0.9397
                                     0       -0.3420     0.9397]);
+sensors.sunsensor_real_voltage_maximums= 3.3 * ones(20, 1);
+sensors.sunsensor_measured_voltage_maximums= sensors.sunsensor_real_voltage_maximums;
 sensors.sunsensor_measured_normals= sensors.sunsensor_real_normals;
 sensors.gps_bias= zeros(6,1);
 sensors.gps_time_till_lock= const.GPS_LOCK_TIME;


### PR DESCRIPTION
Relates to #22.

The full algorithm, as will exists on the ADCS computer, has been implemented. There are now two sets of configuration data. First, you have `sensors.sunsensor_*_normals` which is a matrix on unit vectors representing the normal vectors of each sun sensor in the body frame of the spacecraft. Second, there is the `sensors.sunsensor_*_voltage_maximums` which is vector containing a voltage normalization constant to place each individual diodes measurement with the range `[0, 1]`.

From there we rely on a single least squares problem of the following form:

![equation](https://latex.codecogs.com/gif.latex?%5Cbegin%7Bbmatrix%7D%5Chat%7Bn%7D_1%5ET%5C%5C%5Chat%7Bn%7D_2%5ET%5C%5C%5Cvdots%5C%5C%5Chat%7Bn%7D_n%5ET%5Cend%7Bbmatrix%7D%5Cvec%7Bs%7D%3D%5Cbegin%7Bbmatrix%7Dv_1%5C%5Cv_2%5C%5C%5Cvdots%5C%5Cv_n%5Cend%7Bbmatrix%7D)

Where a given normal vector and it's corresponding voltage measurement is only included if the voltage measurement is above a specified threshold. This has two benefits:
 1. We avoid issues with the dot product actually going negative when the sun vector would be pointing behind a given photodiode
 2. We can ignore edge effects when by setting a relatively high voltage threshold (like `0.5 V` which maps to `30` degrees)

Once the lower voltage measurements are removed from the above system, we solve for a sun vector if we have at least 4 rows in the matrix and RHS vector (this threshold of 4 can be played with but cannot drop below 3 for obvious reasons).

The algorithm was verified correctly by by observing multiple iterations with the MATLAB debugger and looking at `norm(sun_vec - sat2sun, 'fro')` at the end of calls to `update_sun_sensors`.