### PR TITLE
Update to track off lin/master and add lin.hpp

### DIFF
--- a/include/gnc_utilities.hpp
+++ b/include/gnc_utilities.hpp
@@ -13,7 +13,7 @@
 #ifndef PAN_PSIM_INCLUDE_GNC_UTILITIES_HPP_
 #define PAN_PSIM_INCLUDE_GNC_UTILITIES_HPP_
 
-#include <lin.hpp>
+#include "lin.hpp"
 
 #include <cmath>
 

--- a/include/lin.hpp
+++ b/include/lin.hpp
@@ -1,0 +1,21 @@
+//
+// include/gnc_utilities.hpp
+// PSim
+//
+// Contributors:
+//   Kyle Krol  kpk63@cornell.edu
+//
+// Pathfinder for Autonomous Navigation
+// Space Systems Design Studio
+// Cornell Univeristy
+//
+
+#ifndef PAN_PSIM_INCLUDE_LIN_HPP_
+#define PAN_PSIM_INCLUDE_LIN_HPP_
+
+#include "../lin/include/core/core.hpp"
+
+#include "../lin/include/algorithms/backward_sub.hpp"
+#include "../lin/include/algorithms/qr.hpp"
+
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,5 @@ add_library(src
 )
 
 target_include_directories(src PUBLIC
-  ${psim_SOURCE_DIR}/lin/include
   ${psim_SOURCE_DIR}/include
 )


### PR DESCRIPTION
Turns out that Platformio clones recursively!!!! That means we can pin the lin library version on master to a specific commit which is very cool (i.e. we don't always need to pull in the latest updates from the lin alg library). I've updated it here so `lin.hpp` will be included from the psim repo.

The lin submodule now tracks off of the master branch. This way, if updates are needed you can follow the same workflow within the lin repo by creating a new branch, making changes, ensuring everything works, opening a PR in the lin repo, updating the lin submodule to track off the new commit, and then making a PSim PR.