### PR TITLE
Added Ode23 Implementation and Unit Tests

### DIFF
--- a/include/gnc_ode.hpp
+++ b/include/gnc_ode.hpp
@@ -44,7 +44,29 @@
 #define PAN_GNC_ODEX_MULTI_EXTERN_TEMPLATE(odex, type) \
     extern PAN_GNC_ODEX_MULTI_TEMPLATE(odex, type)
 
+#define PAN_GNC_ODEXX_TEMPLATE(odexx, type) \
+    template \
+    int odexx<type>(type, type, type const *, type *, unsigned int, type *, \
+        type, type, type, unsigned int, void (*const)(type, type const *, type *));
+
+#define PAN_GNC_ODEXX_EXTERN_TEMPLATE(odexx, type) \
+    extern PAN_GNC_ODEXX_TEMPLATE(odexx, type)
+
 namespace gnc {
+
+/** @enum ode_err_t
+ *  Odexx function error codes. Multiple codes may combined using a bitwise or
+ *  operation. */
+enum : int {
+  /** Zero response code indicate nominal execution (is not a bitmask). */
+  ODE_ERR_OK = 0,
+  /** A step size below the specified minimum was requested. */
+  ODE_ERR_MIN_STEP = (0b1 << 0),
+  /** The max number of iterations was reached (integration is incomplete). */
+  ODE_ERR_MAX_ITER = (0b1 << 1),
+  /** The time interval was ill formatted (integration is incomplete). */
+  ODE_ERR_BAD_INTERVAL = (0b1 << 2)
+};
 
 /** @fn ode1
  *  @param[in]  ti Initial conditions for the independant variable.
@@ -197,6 +219,30 @@ void ode4(T const *t, unsigned int nt, T **y, unsigned int ne, T *bf,
 
 PAN_GNC_ODEX_MULTI_EXTERN_TEMPLATE(ode4, float);
 PAN_GNC_ODEX_MULTI_EXTERN_TEMPLATE(ode4, double);
+
+/** @fn ode23
+ *  @param[in]  ti       Initial conditions for the independant variable.
+ *  @param[in]  tf       Desired final state for the independant variable.
+ *  @param[in]  yi       Initial conditions of the dependant variables.
+ *  @param[out] yf       Final state of the system (dependant variables).
+ *  @param[in]  ne       Number of dependant variables.
+ *  @param[in]  bf       Buffer of length (6 * ne).
+ *  @param[in]  h_min    Minimum timestep allowed.
+ *  @param[in]  rel_tol  Relative tolerance.
+ *  @param[in]  abs_tol  Absolute tolerance.
+ *  @param[in]  max_iter Maximum number of allowed iterations.
+ *  @param[in]  f        Dependant variable update function.
+ *  @returns Zero on success (see implementation for more details).
+ *  Integrates the system using a variable step size second-third order method
+ *  from (ti, yi) -> (tf, yf) where yf is essentially the output. The step size
+ *  is bounded from below by hm.
+ *  NOTE: Template specializations are provided for double and float types. */
+template <typename T>
+int ode23(T ti, T tf, T const *yi, T *yf, unsigned int ne, T *bf, T h_min,
+    T rel_tol, T abs_tol, unsigned int max_iter, void (*const f)(T, T const *, T *));
+
+PAN_GNC_ODEXX_EXTERN_TEMPLATE(ode23, float);
+PAN_GNC_ODEXX_EXTERN_TEMPLATE(ode23, double);
 
 }  // namespace gnc
 

--- a/include/gnc_ode.hpp
+++ b/include/gnc_ode.hpp
@@ -235,7 +235,7 @@ PAN_GNC_ODEX_MULTI_EXTERN_TEMPLATE(ode4, double);
  *  @returns Zero on success (see implementation for more details).
  *  Integrates the system using a variable step size second-third order method
  *  from (ti, yi) -> (tf, yf) where yf is essentially the output. The step size
- *  is bounded from below by hm.
+ *  is bounded from below by h_min.
  *  NOTE: Template specializations are provided for double and float types. */
 template <typename T>
 int ode23(T ti, T tf, T const *yi, T *yf, unsigned int ne, T *bf, T h_min,
@@ -243,6 +243,30 @@ int ode23(T ti, T tf, T const *yi, T *yf, unsigned int ne, T *bf, T h_min,
 
 PAN_GNC_ODEXX_EXTERN_TEMPLATE(ode23, float);
 PAN_GNC_ODEXX_EXTERN_TEMPLATE(ode23, double);
+
+/** @fn ode45
+ *  @param[in]  ti       Initial conditions for the independant variable.
+ *  @param[in]  tf       Desired final state for the independant variable.
+ *  @param[in]  yi       Initial conditions of the dependant variables.
+ *  @param[out] yf       Final state of the system (dependant variables).
+ *  @param[in]  ne       Number of dependant variables.
+ *  @param[in]  bf       Buffer of length (9 * ne).
+ *  @param[in]  h_min    Minimum timestep allowed.
+ *  @param[in]  rel_tol  Relative tolerance.
+ *  @param[in]  abs_tol  Absolute tolerance.
+ *  @param[in]  max_iter Maximum number of allowed iterations.
+ *  @param[in]  f        Dependant variable update function.
+ *  @returns Zero on success (see implementation for more details).
+ *  Integrates the system using a variable step size fourth-fifth order method
+ *  from (ti, yi) -> (tf, yf) where yf is essentially the output. The step size
+ *  is bounded from below by h_min.
+ *  NOTE: Template specializations are provided for double and float types. */
+template <typename T>
+int ode45(T ti, T tf, T const *yi, T *yf, unsigned int ne, T *bf, T h_min,
+    T rel_tol, T abs_tol, unsigned int max_iter, void (*const f)(T, T const *, T *));
+
+PAN_GNC_ODEXX_EXTERN_TEMPLATE(ode45, float);
+PAN_GNC_ODEXX_EXTERN_TEMPLATE(ode45, double);
 
 }  // namespace gnc
 

--- a/src/gnc_ode.cpp
+++ b/src/gnc_ode.cpp
@@ -172,7 +172,7 @@ int ode23(T ti, T tf, T const *yi, T *yf, unsigned int ne, T *bf, T h_min,
   constexpr static T bs1 = 7.0L / 24.0L, bs2 = 1.0L / 4.0L, bs3 = 1.0L / 3.0L, bs4 = 1.0L / 8.0L;
   constexpr static T c2 = 1.0L / 2.0L, c3 = 3.0L / 4.0L;
 
- // Setup scratch buffers
+  // Setup scratch buffers
   T *const k1 = bf;
   T *const k2 = k1 + ne;
   T *const k3 = k2 + ne;
@@ -184,7 +184,7 @@ int ode23(T ti, T tf, T const *yi, T *yf, unsigned int ne, T *bf, T h_min,
   bool calc_k1 = true;
   int err = ODE_ERR_OK;
   unsigned int iter = 0;
-  T h_next = (tf - ti) / static_cast<T>(10);
+  T h_next = (tf - ti) / static_cast<T>(100);
   T t = ti;
   T delta_max;
   T h;
@@ -229,8 +229,7 @@ int ode23(T ti, T tf, T const *yi, T *yf, unsigned int ne, T *bf, T h_min,
       }
 
       // Helpfull constants
-      constexpr static T one = static_cast<T>(1), three = static_cast<T>(3),
-          one_third = one / three;
+      constexpr static T one = 1.0L, three = 3.0L, one_third = one / three;
       
       // Extremely small error (prevent divide by zero and bump step size)
       if (delta_max < static_cast<T>(1e-20)) {
@@ -272,5 +271,141 @@ int ode23(T ti, T tf, T const *yi, T *yf, unsigned int ne, T *bf, T h_min,
 
 PAN_GNC_ODEXX_TEMPLATE(ode23, float);
 PAN_GNC_ODEXX_TEMPLATE(ode23, double);
+
+// Reference:
+//  https://en.wikipedia.org/wiki/Dormand–Prince_method
+//  Earl Kirkland example code and notes from AEP 4380
+//  Numerical Recipes 3rd Edition: The Art of Scientific Computing
+template <typename T>
+int ode45(T ti, T tf, T const *yi, T *yf, unsigned int ne, T *bf, T h_min,
+    T rel_tol, T abs_tol, unsigned int max_iter, void (*const f)(T, T const *, T *)) {
+  // Table of values
+  constexpr static T a21 = 1.0L / 5.0L,
+      a31 = 3.0L / 40.0L, a32 = 9.0L / 40.0L,
+      a41 = 44.0L / 45.0L, a42 = -56.0L / 15.0L, a43 = 32.0L / 9.0L,
+      a51 = 19372.0L / 6561.0L, a52 = -25360.0L / 2187.0L,
+        a53 = 64448.0L / 6561.0L, a54 = -212.0L / 729.0L,
+      a61 = 9017.0L / 3168.0L, a62 = -355.0L / 33.0L, a63 = 46732.0L / 5247.0L,
+        a64 = 49.0L / 176.0L, a65 = -5103.0L / 18656.0L,
+      a71 = 35.0L / 384.0L, a73 = 500.0L / 1113.0L, a74 = 125.0L / 192.0L,
+        a75 = -2187.0L / 6784.0L, a76 = 11.0L / 84.0L;
+  constexpr static T bs1 = 5179.0L / 57600.0L, bs3 = 7571.0L / 16695.0L,
+      bs4 = 393.0L / 640.0L, bs5 = -92097.0L / 339200.0L,
+      bs6 = 187.0L / 2100.0L, bs7 = 1.0L / 40.0L;
+  constexpr static T c2 = 1.0L / 5.0L, c3 = 3.0L / 10.0L, c4 = 4.0L / 5.0L,
+      c5 = 8.0L / 9.0L;
+
+  // Setup scratch buffers
+  T *const k1 = bf;
+  T *const k2 = k1 + ne;
+  T *const k3 = k2 + ne;
+  T *const k4 = k3 + ne;
+  T *const k5 = k4 + ne;
+  T *const k6 = k5 + ne;
+  T *const k7 = k6 + ne;
+  T *const ks = k7 + ne;
+  T *const kz = ks + ne;
+
+  // Initialize local variables
+  bool calc_k1 = true;
+  int err = ODE_ERR_OK;
+  unsigned int iter = 0;
+  T h_next = (tf - ti) / static_cast<T>(100);
+  T t = ti;
+  T delta_max;
+  T h;
+
+  // Copy yi into yf and ensure we still have some time to integrate over
+  for (unsigned int i = 0; i < ne; i++) yf[i] = yi[i];
+  if (ti >= tf) return err | ODE_ERR_BAD_INTERVAL;
+
+  for (;;) {
+
+    // Check iteration bound
+    if (iter++ > max_iter) return err | ODE_ERR_MAX_ITER;
+
+    for (;;) {  // Start error checking loop
+
+      // Setup
+      h = h_next;
+      if (calc_k1) {
+        f(t, yf, k1);
+        calc_k1 = true;
+      }
+
+      // Step forward
+      for (unsigned int i = 0; i < ne; i++)
+        ks[i] = yf[i] + h * a21 * k1[i];
+      f(t + c2 * h, ks, k2);
+      for (unsigned int i = 0; i < ne; i++)
+        ks[i] = yf[i] + h * (a31 * k1[i] + a32 * k2[i]);
+      f(t + c3 * h, ks, k3);
+      for (unsigned int i = 0; i < ne; i++)
+        ks[i] = yf[i] + h * (a41 * k1[i] + a42 * k2[i] + a43 * k2[i]);
+      f(t + c4 * h, ks, k4);
+      for (unsigned int i = 0; i < ne; i++)
+        ks[i] = yf[i] + h * (a51 * k1[i] + a52 * k2[i] + a53 * k3[i] + a54 * k4[i]);
+      f(t + c5 * h, ks, k5);
+      for (unsigned int i = 0; i < ne; i++)
+        ks[i] = yf[i] + h * (a61 * k1[i] + a62 * k2[i] + a63 * k3[i] + a64 * k4[i] + a65 * k5[i]);
+      f(t + h, ks, k6);
+      for (unsigned int i = 0; i < ne; i++)
+        ks[i] = yf[i] + h * (a71 * k1[i] + a73 * k3[i] + a74 * k4[i] + a75 * k5[i] + a76 * k6[i]);
+      f(t + h, ks, k7);
+      for (unsigned int i = 0; i < ne; i++)
+        kz[i] = yf[i] +
+            h * (bs1 * k1[i] + bs3 * k3[i] + bs4 * k4[i] + bs5 * k5[i] + bs6 * k6[i] + bs7 * k7[i]);
+
+      // Calculate largest error
+      delta_max = static_cast<T>(0);
+      for (unsigned int i = 0; i < ne; i++) {
+        T delta = abs( ks[i] - kz[i] ) /
+            std::max(abs_tol, rel_tol * std::max(abs(ks[i]), abs(kz[i])));
+        if (delta > delta_max) delta_max = delta;
+      }
+
+      // Helpfull constants
+      constexpr static T one = 1.0L, five = 5.0L, one_fifth = one / five;
+
+      // Extremely small error (prevent divide by zero and bump step size)
+      if (delta_max < static_cast<T>(1e-20)) {
+        h_next = h * five;
+      }
+      // Small error (bump step size a little)
+      else if (delta_max < one_fifth) {
+        h_next = h * pow(one / delta_max, one_fifth);
+      }
+      // Large error (shrink step size, ensure it large enough, and continue)
+      else if (delta_max > one) {
+        h_next = h * one_fifth;
+        if (h_next < h_min) {
+          h_next = h_min;
+          err |= ODE_ERR_MIN_STEP;
+        }
+        continue;
+      }
+      // Step size is working well (don't calculate the next k1 vector)
+      else {
+        for (unsigned int i = 0; i < ne; i++) k1[i] = k7[i];
+        calc_k1 = false;
+        h_next = h;
+      }
+
+      // Exit loop to update yf and t
+      break;
+      
+    }  // End error checking loop
+
+    // Step forward time, see if we're done, and prevent to large of a step
+    t += h;
+    for (unsigned int i = 0; i < ne; i++) yf[i] = ks[i];
+    if (t >= tf) return err;
+    if (t + h_next >= tf) h_next = tf - t;
+
+  }
+}
+
+PAN_GNC_ODEXX_TEMPLATE(ode45, float);
+PAN_GNC_ODEXX_TEMPLATE(ode45, double);
 
 }  // namespace gnc

--- a/tests/ode_test.cpp
+++ b/tests/ode_test.cpp
@@ -94,6 +94,8 @@ TEST(OdeTest, Ode23ShoTest) {
   // Check against cos(1.0) and assert the error code is OK
   code = gnc::ode23(ti, 1.0, yi, yf, ne, bf, 1e-4, 1e-6, 1e-6, 1000, fsho);
   ASSERT_EQ(code, gnc::ODE_ERR_OK);
+  std::cout << "yf[0] = " << yf[0] << " cos(1.0) = " << cos(1.0) << std::endl;
+  std::cout << "yf[0] - cos(1.0) = " << (yf[0] - cos(1.0)) << std::endl;
   ASSERT_NEAR(yf[0], cos(1.0), 1e-3);
   // Check against cos(5.0) and assert the error code is OK
   code = gnc::ode23(ti, 5.0, yi, yf, ne, bf, 1e-4, 1e-6, 1e-6, 1000, fsho);
@@ -105,6 +107,27 @@ TEST(OdeTest, Ode23ShoTest) {
   ASSERT_NEAR(yf[0], cos(6.5), 1e-3);
   // Check against cos(7.5) and assert the error code is OK
   code = gnc::ode23(ti, 7.5, yi, yf, ne, bf, 1e-4, 1e-6, 1e-6, 2000, fsho);
+  ASSERT_EQ(code, gnc::ODE_ERR_OK);
+  ASSERT_NEAR(yf[0], cos(7.5), 2e-3);
+}
+
+TEST(OdeTest, Ode45ShoTest) {
+  PAN_GNC_ODEXX_TEST_VARS(9);
+  int code;
+  // Check against cos(1.0) and assert the error code is OK
+  code = gnc::ode45(ti, 1.0, yi, yf, ne, bf, 1e-4, 1e-6, 1e-6, 1000, fsho);
+  ASSERT_EQ(code, gnc::ODE_ERR_OK);
+  ASSERT_NEAR(yf[0], cos(1.0), 1e-3);
+  // Check against cos(5.0) and assert the error code is OK
+  code = gnc::ode45(ti, 5.0, yi, yf, ne, bf, 1e-4, 1e-6, 1e-6, 1000, fsho);
+  ASSERT_EQ(code, gnc::ODE_ERR_OK);
+  ASSERT_NEAR(yf[0], cos(5.0), 1e-3);
+  // Check against cos(6.5) and assert the error code is OK
+  code = gnc::ode45(ti, 6.5, yi, yf, ne, bf, 1e-4, 1e-6, 1e-6, 1000, fsho);
+  ASSERT_EQ(code, gnc::ODE_ERR_OK);
+  ASSERT_NEAR(yf[0], cos(6.5), 1e-3);
+  // Check against cos(7.5) and assert the error code is OK
+  code = gnc::ode45(ti, 7.5, yi, yf, ne, bf, 1e-4, 1e-6, 1e-6, 2000, fsho);
   ASSERT_EQ(code, gnc::ODE_ERR_OK);
   ASSERT_NEAR(yf[0], cos(7.5), 2e-3);
 }

--- a/tests/ode_test.cpp
+++ b/tests/ode_test.cpp
@@ -12,9 +12,10 @@
 
 #include <gnc_ode.hpp>
 
+#include <cmath>
 #include <gtest/gtest.h>
 
-#define PAN_GNC_ODE_TEST_VARS(n) \
+#define PAN_GNC_ODEX_TEST_VARS(n) \
     unsigned int const nt = 4; \
     unsigned int const ne = 2; \
     double const t[nt] = { 0.0, 0.1, 0.2, 0.3 }; \
@@ -26,13 +27,20 @@
     y[0][0] = 1.0; \
     y[0][1] = 0.0;
 
+#define PAN_GNC_ODEXX_TEST_VARS(n) \
+    unsigned int const ne = 2; \
+    double const ti = 0.0; \
+    double const yi[ne] = { 1.0, 0.0 }; \
+    double yf[ne]; \
+    double bf[n * ne];
+
 static void fsho(double t, double const *y, double *dy) {
   dy[0] = y[1];
   dy[1] = -y[0];
 }
 
 TEST(OdeTest, Ode1ShoTest) {
-  PAN_GNC_ODE_TEST_VARS(1)
+  PAN_GNC_ODEX_TEST_VARS(1)
   gnc::ode1(t, nt, y, ne, bf, fsho);
   // Check against MATLAB output
   ASSERT_FLOAT_EQ(y[1][0],  1.000000000000000);
@@ -44,7 +52,7 @@ TEST(OdeTest, Ode1ShoTest) {
 }
 
 TEST(OdeTest, Ode2ShoTest) {
-  PAN_GNC_ODE_TEST_VARS(3)
+  PAN_GNC_ODEX_TEST_VARS(3)
   gnc::ode2(t, nt, y, ne, bf, fsho);
   // Check against MATLAB output
   ASSERT_FLOAT_EQ(y[1][0],  0.995000000000000);
@@ -56,7 +64,7 @@ TEST(OdeTest, Ode2ShoTest) {
 }
 
 TEST(OdeTest, Ode3ShoTest) {
-  PAN_GNC_ODE_TEST_VARS(4)
+  PAN_GNC_ODEX_TEST_VARS(4)
   gnc::ode3(t, nt, y, ne, bf, fsho);
   // Check against MATLAB output
   ASSERT_FLOAT_EQ(y[1][0],  0.995000000000000);
@@ -68,7 +76,7 @@ TEST(OdeTest, Ode3ShoTest) {
 }
 
 TEST(OdeTest, Ode4ShoTest) {
-  PAN_GNC_ODE_TEST_VARS(5)
+  PAN_GNC_ODEX_TEST_VARS(5)
   gnc::ode4(t, nt, y, ne, bf, fsho);
   // Check against MATLAB output
   ASSERT_FLOAT_EQ(y[1][0],  0.995004166666667);
@@ -78,4 +86,25 @@ TEST(OdeTest, Ode4ShoTest) {
   ASSERT_FLOAT_EQ(y[3][0],  0.955336542863976);
   ASSERT_FLOAT_EQ(y[3][1], -0.295519962530663);
   // ASSERT_FLOAT_EQ(y[3][1], -0.295520962530663); Fails as expected
+}
+
+TEST(OdeTest, Ode23ShoTest) {
+  PAN_GNC_ODEXX_TEST_VARS(6);
+  int code;
+  // Check against cos(1.0) and assert the error code is OK
+  code = gnc::ode23(ti, 1.0, yi, yf, ne, bf, 1e-4, 1e-6, 1e-6, 1000, fsho);
+  ASSERT_EQ(code, gnc::ODE_ERR_OK);
+  ASSERT_NEAR(yf[0], cos(1.0), 1e-3);
+  // Check against cos(5.0) and assert the error code is OK
+  code = gnc::ode23(ti, 5.0, yi, yf, ne, bf, 1e-4, 1e-6, 1e-6, 1000, fsho);
+  ASSERT_EQ(code, gnc::ODE_ERR_OK);
+  ASSERT_NEAR(yf[0], cos(5.0), 1e-3);
+  // Check against cos(6.5) and assert the error code is OK
+  code = gnc::ode23(ti, 6.5, yi, yf, ne, bf, 1e-4, 1e-6, 1e-6, 1000, fsho);
+  ASSERT_EQ(code, gnc::ODE_ERR_OK);
+  ASSERT_NEAR(yf[0], cos(6.5), 1e-3);
+  // Check against cos(7.5) and assert the error code is OK
+  code = gnc::ode23(ti, 7.5, yi, yf, ne, bf, 1e-4, 1e-6, 1e-6, 2000, fsho);
+  ASSERT_EQ(code, gnc::ODE_ERR_OK);
+  ASSERT_NEAR(yf[0], cos(7.5), 2e-3);
 }


### PR DESCRIPTION
Relates to #66 #67 #47

Figured I may as well split up the PRs for `ode23` and `ode45` in case we want to change the interface for variable step size integrators.

Also, having a variable step size integrator complete will allow work on #66 and #47 to progress quicker even if the integrator isn't terribly accurate.