### PR TITLE
Added Docker Support to Aid with GCC Specific Debugging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Dockerfile for running PlatformIO unit tests in a Linux environment. This is
+# specifically to allow Mac developers to troubleshoot potential precision
+# issues as seen in the past.
+#
+
+FROM ubuntu:18.04
+
+RUN \
+  apt-get update && \
+  apt-get -y upgrade && \
+  apt-get install -y \
+    python3 \
+    python3-pip
+
+RUN \
+  python3 -m pip install \
+    platformio
+
+# Following two environment variables were required for PIO
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
+RUN \
+  platformio update

--- a/tools/docker_build.sh
+++ b/tools/docker_build.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Builds the docker container used for Ubuntu gcc testing. This script needs to
+# be called from the root PSim directory!
+#
+
+docker image build -t psim:latest .
+
+exit $?

--- a/tools/docker_test.sh
+++ b/tools/docker_test.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Starts a docker container and copies in your current local copy of PSim into
+# the '/root/psim' directory. From there you can run the CI tests with the
+# following command: 'platformio test -v -e ci_native'. This script needs to be
+# called from the root PSim directory!
+#
+
+readonly id=$(docker create --rm -it psim:latest) &&
+docker cp . "$id:/root/psim" &&
+docker start -i "$id"
+
+exit $?


### PR DESCRIPTION
Relates to #74.

If you haven't used Docker before I'd give it a look. It essentially let's you host really lightweight VM's to create extremely encapsulated, reproducible development environments independent of operating system - technically they aren't always VMs but you can read more into that if you'd like.

To boot up the Docker yourself, simply make sure docker is installed and then run the following form the root PSim directory (if you're on Windows this may not work but the commands from within the files can almost be copied):

    ./tools/docker_build.sh
    ./tools/docker_test.sh

The latter will boot up a Docker container and ssh you into it. From there you can run the following to build and execute the unit tests:

    cd ~/root/psim && platformio test -v -e ci_native

See the script files for more documentation.