### PR TITLE
Fixed Ode23 Precision Issue with GCC

### DIFF
--- a/src/gnc_ode.cpp
+++ b/src/gnc_ode.cpp
@@ -223,8 +223,8 @@ int ode23(T ti, T tf, T const *yi, T *yf, unsigned int ne, T *bf, T h_min,
       // Calculate largest error
       delta_max = static_cast<T>(0);
       for (unsigned int i = 0; i < ne; i++) {
-        T delta = abs( ks[i] - kz[i] ) /
-            std::max(abs_tol, rel_tol * std::max(abs(ks[i]), abs(kz[i])));
+        T delta = std::abs( ks[i] - kz[i] ) /
+            std::max(abs_tol, rel_tol * std::max(std::abs(ks[i]), std::abs(kz[i])));
         if (delta > delta_max) delta_max = delta;
       }
 
@@ -238,7 +238,7 @@ int ode23(T ti, T tf, T const *yi, T *yf, unsigned int ne, T *bf, T h_min,
       }
       // Small error (bump step size a little)
       else if (delta_max < one_third) {
-        h_next = h * pow(one / delta_max, one_third);
+        h_next = h * std::pow(one / delta_max, one_third);
       }
       // Large error (shrink step size, ensure it large enough, and continue)
       else if (delta_max > one) {

--- a/test/ode_test/test.cpp
+++ b/test/ode_test/test.cpp
@@ -86,7 +86,6 @@ void test_ode_ode4sho() {
   TEST_ASSERT_EQUAL_DOUBLE(-0.295519962530663, y[3][1]);
 }
 
-#ifndef CI_BUILD
 void test_ode_ode23sho() {
   PAN_GNC_ODEXX_TEST_VARS(6);
   int code;
@@ -107,14 +106,11 @@ void test_ode_ode23sho() {
   TEST_ASSERT_EQUAL_INT(gnc::ODE_ERR_OK, code);
   TEST_ASSERT_DOUBLE_WITHIN(2e-3, cos(7.5), yf[0]);
 }
-#endif
 
 void test() {
   RUN_TEST(test_ode_ode1sho);
   RUN_TEST(test_ode_ode2sho);
   RUN_TEST(test_ode_ode3sho);
   RUN_TEST(test_ode_ode4sho);
-#ifndef CI_BUILD
   RUN_TEST(test_ode_ode23sho);
-#endif
 }


### PR DESCRIPTION
Closes #74.

This ended up being a super simple fix (lucky for us). I'm not 100% sure I totally understand what's going on but here seems to be the short version.

`#include <cmath>` also pulls in an `#include <cmath.h>`. This has the implication that all of the standard C math functions are imported into the global namespace. So doing something like `cos(...)` is not overload for `float`, `double`, `long double`, `std::complex<...>`, etc like you'd expect it to be in CXX. To use the actual STL math functions you MUST reference them through `::std`!

Why does this has that big of an effect? No idea. I'd imagine the age of GCC vs Clang could have something to do with it...?

I also noticed through a little bit more digging in the STL source code that that 'built-in' math functions are already handled for you, per type, in the STL (little bonus for us).

Super short version, only use math functions from `::std` and we should be fine. I will be opening up another ticket to make note of this and track any changes that need to be made to the code. All I can think of at the moment is a stray call to `sqrt(...)` in `lin::norm(...)`.