### PR TITLE
Draft of Attitude Estimator Function

### DIFF
--- a/include/gnc_attitude_estimation.hpp
+++ b/include/gnc_attitude_estimation.hpp
@@ -1,0 +1,62 @@
+//
+// include/gnc_attitude_estimation.hpp
+// PSim
+//
+// Contributors:
+//   Kyle Krol  kpk63@cornell.edu
+//
+// Pathfinder for Autonomous Navigation
+// Space Systems Design Studio
+// Cornell Univeristy
+//
+
+#ifndef PAN_PSIM_INCLUDE_GNC_ATTITUDE_ESTIMATION_HPP_
+#define PAN_PSIM_INCLUDE_GNC_ATTITUDE_ESTIMATION_HPP_
+
+#include "lin.hpp"
+
+namespace gnc {
+
+/** @struct AttitudeEstimatorState
+ *  Contains internal state information needed by the estimate_attitude
+ *  function. */
+struct AttitudeEstimatorState {
+  double t;
+  lin::Vector4f q_body_eci;
+  /** Defaults everything's value to NaN. */
+  AttitudeEstimatorState();
+};
+
+/** @struct AttitudeEstimatorData */
+struct AttitudeEstimatorData {
+  /** Timestamp for the rest of the data in this struct and the time for which
+   *  an attitude estimate will be calculated. This should be in seconds since
+   *  the 'PAN epoch'. */
+  double t;
+  /** Position of the satellite in ECEF (units m). */
+  lin::Vector3d r_ecef;
+  /** Magnetic field vector in the body frame of the spacecraft (units T). */
+  lin::Vector3f b_body;
+  /** Sun vector in the body frame of the spacecraft (unit vector). */
+  lin::Vector3f s_body;
+  /** Defaults everything's value to NaN. */
+  AttitudeEstimatorData();
+};
+
+/** @struct AttitudeEstimate */
+struct AttitudeEstimate {
+  /** Quaternion transforming from the body frame to ECI. */
+  lin::Vector4f q_body_eci;
+  /** Angular rate of the spacecraft in the body frame. */
+  lin::Vector3f w_body;
+  /** Defaults everything's value to NaN. */
+  AttitudeEstimate();
+};
+
+/** @fn estimate_attitude */
+void estimate_attitude(AttitudeEstimatorState &state,
+    AttitudeEstimatorData const &data, AttitudeEstimate &estimate);
+
+}  // namespace gnc
+
+#endif

--- a/src/gnc_attitude_estimation.cpp
+++ b/src/gnc_attitude_estimation.cpp
@@ -81,9 +81,13 @@ void estimate_attitude(AttitudeEstimatorState &state,
   if (data.t - state.t > 1.0) state = AttitudeEstimatorState();
 
   // Query the magnetic field and sun vector environmental models
-  lin::Vector3f b_eci, s_eci;
+  lin::Vector3f b_eci, s_eci, r_ecef = {
+    static_cast<float>(data.r_ecef(0)),
+    static_cast<float>(data.r_ecef(1)),
+    static_cast<float>(data.r_ecef(2))
+  };
   env::sun_vector(data.t, s_eci);
-  env::magnetic_field(data.t, data.r_ecef, b_eci);
+  env::magnetic_field(data.t, r_ecef, b_eci);
 
   // Perform triad and check result
   lin::Vector4f q_body_eci;

--- a/src/gnc_attitude_estimation.cpp
+++ b/src/gnc_attitude_estimation.cpp
@@ -1,0 +1,104 @@
+//
+// src/gnc_attitude_estimationr.cpp
+// PSim
+//
+// Contributors:
+//   Kyle Krol  kpk63@cornell.edu
+//
+// Pathfinder for Autonomous Navigation
+// Space Systems Design Studio
+// Cornell Univeristy
+//
+
+#include <gnc_attitude_estimation.hpp>
+#include <gnc_environment.hpp>
+#include <gnc_utilities.hpp>
+
+#include <cmath>
+#include <limits>
+
+static_assert(std::numeric_limits<double>::has_quiet_NaN,
+    "GNC code requires quiet NaN's to be available.");
+static_assert(std::numeric_limits<float>::has_quiet_NaN,
+    "GNC code requires quiet NaN's to be available.");
+
+namespace gnc {
+
+AttitudeEstimatorState::AttitudeEstimatorState() {
+  this->t = std::numeric_limits<double>::quiet_NaN();
+  this->q_body_eci = {
+    std::numeric_limits<float>::quiet_NaN(),
+    std::numeric_limits<float>::quiet_NaN(),
+    std::numeric_limits<float>::quiet_NaN(),
+    std::numeric_limits<float>::quiet_NaN()
+  };
+}
+
+AttitudeEstimatorData::AttitudeEstimatorData() {
+  this->t = std::numeric_limits<double>::quiet_NaN();
+  this->r_ecef = {
+    std::numeric_limits<double>::quiet_NaN(),
+    std::numeric_limits<double>::quiet_NaN(),
+    std::numeric_limits<double>::quiet_NaN(),
+    std::numeric_limits<double>::quiet_NaN()
+  };
+  this->b_body = {
+    std::numeric_limits<float>::quiet_NaN(),
+    std::numeric_limits<float>::quiet_NaN(),
+    std::numeric_limits<float>::quiet_NaN()
+  };
+  this->s_body = {
+    std::numeric_limits<float>::quiet_NaN(),
+    std::numeric_limits<float>::quiet_NaN(),
+    std::numeric_limits<float>::quiet_NaN()
+  };
+}
+
+AttitudeEstimate::AttitudeEstimate() {
+  this->q_body_eci = {
+    std::numeric_limits<float>::quiet_NaN(),
+    std::numeric_limits<float>::quiet_NaN(),
+    std::numeric_limits<float>::quiet_NaN(),
+    std::numeric_limits<float>::quiet_NaN()
+  };
+  this->w_body = {
+    std::numeric_limits<float>::quiet_NaN(),
+    std::numeric_limits<float>::quiet_NaN(),
+    std::numeric_limits<float>::quiet_NaN()
+  };
+}
+
+void estimate_attitude(AttitudeEstimatorState &state,
+    AttitudeEstimatorData const &data, AttitudeEstimate &estimate) {
+
+  // Default everything to NaN and ensure the magnetic field vector, sun vector,
+  // and ECEF position were given
+  estimate = AttitudeEstimate();
+  if (std::isnan(data.b_body(0)) || std::isnan(data.s_body(0)) || std::isnan(data.r_ecef(0)))
+    return;
+
+  // Clear the state if it's outdated
+  if (data.t - state.t > 1.0) state = AttitudeEstimatorState();
+
+  // Query the magnetic field and sun vector environmental models
+  lin::Vector3f b_eci, s_eci;
+  env::sun_vector(data.t, s_eci);
+  env::magnetic_field(data.t, data.r_ecef, b_eci);
+
+  // Perform triad and check result
+  lin::Vector4f q_body_eci;
+  int code = utl::triad(s_eci, b_eci, data.s_body, data.b_body, q_body_eci);
+  if (code) return;
+  
+  // Update the estimate and perform the time derivative
+  estimate.q_body_eci = q_body_eci;
+
+  // Record the determined state for the next iteration
+  state = AttitudeEstimatorState();
+  state.t = data.t;
+  state.q_body_eci = q_body_eci;
+
+  // TODO : Add estimation for angular rate
+
+}
+}  // namespace gnc


### PR DESCRIPTION
Relates to #66.

Here is what I would consider a fairly finalized draft of the GNC v1.0 attitude estimation function. Let me know what we all think!

I think the struct design paradigm here is very beneficial for a couple reasons:
 1. All data not specified will come back as `NaN`. This make it easy to handle optional data and very clear when some value wasn't calculate properly. I will work on adding limited `NaN` support to lin so the amount of boilerplate code can be reduced.
 2. Adding extra input variables won't break FSW builds! The variable just won't be set until FSW is updated. This will greatly reduce the amount of versioning we need to do.
 3. It prevents us from having a million input arguments.
 4. We don't have to pass any `nullptr`'s around or have pointers to pointers.

Let me know your thoughts! I will restructure the orbit estimator to mirror the structure presented here a little more closely.

The standard usage pattern I had in mind would be something like this:

    AttitudeEstimatorState state;
    AttitudeEstimate estimate;

    repeat {

      AttitudeEstimatorData data;  // Initial populate everything win NaN
      data.t = ...  // Assign all known data
      ...

      gnc::estimate_attitude(state, data, estimate);

      ... = estimate.q_body_eci;  // Extract all outputs and check for NaN
      ...
    
    }