### PR TITLE
Added Attitude Detumble Controller

### DIFF
--- a/include/gnc_attitude_controller.hpp
+++ b/include/gnc_attitude_controller.hpp
@@ -1,0 +1,66 @@
+//
+// include/gnc_attitude_controller.hpp
+// PSim
+//
+// Contributors:
+//   Kyle Krol  kpk63@cornell.edu
+//
+// Pathfinder for Autonomous Navigation
+// Space Systems Design Studio
+// Cornell Univeristy
+//
+
+#ifndef PAN_PSIM_INCLUDE_GNC_ATTITUDE_CONTROLLER_HPP_
+#define PAN_PSIM_INCLUDE_GNC_ATTITUDE_CONTROLLER_HPP_
+
+#include "gnc_containers.hpp"
+#include "lin.hpp"
+
+namespace gnc {
+
+/** @struct DetumbleControllerState
+ *  Contains internal state information needed by the control_detumble function.
+ *  */
+struct DetumbleControllerState {
+  double t;
+  lin::Vector3f b_body;
+  CircularBuffer<lin::Vector3f, 5> db_buffer;
+  /** Defaults everything's value to NaN. */
+  DetumbleControllerState();
+};
+
+/** @struct DetumbleControllerData
+ *  Essentially serves as the inputs to the control_detumble function. See
+ *  member documentation for more details. */
+struct DetumbleControllerData {
+  /** Timestamp for the rest of the data in this struct and the time for which
+   *  an attitude actuation will be calculated. This should be in seconds since
+   *  the 'PAN epoch'. */
+  double t;
+  /** Observed magnetic field in the body frame of the spacecraft. */
+  lin::Vector3f b_body;
+  /** Defaults everything's value to NaN. */
+  DetumbleControllerData();
+};
+
+/** @struct DetumbleActuation
+ *  Essentially serves as the outputs to the control_detumble function. See
+ *  member documentation for more details. */
+struct DetumbleActuation {
+  /** Magnetourquer actuation command in the body frame (units Am^2) */
+  lin::Vector3f mtr_body_cmd;
+  /** Defaults everything's value to NaN. */
+  DetumbleActuation();
+};
+
+/** @fn control_detumble
+ *  @brief Calculation MTR actuations to detumble the spacecraft.
+ *  @param[inout] state     Control function internal state information.
+ *  @param[in]    data      Control function inputs
+ *  @param[out]   actuation Actuation output. */
+void control_detumble(DetumbleControllerState &state,
+    DetumbleControllerData const &data, DetumbleActuation &actuation);
+
+}  // namespace gnc
+
+#endif

--- a/include/gnc_attitude_controller.hpp
+++ b/include/gnc_attitude_controller.hpp
@@ -22,9 +22,8 @@ namespace gnc {
  *  Contains internal state information needed by the control_detumble function.
  *  */
 struct DetumbleControllerState {
-  double t;
-  lin::Vector3f b_body;
-  CircularBuffer<lin::Vector3f, 5> db_buffer;
+  lin::Vector3f mtr_body_cmd;
+  CircularBuffer<lin::Vector3f, 10> b_body_buffer;
   /** Defaults everything's value to NaN. */
   DetumbleControllerState();
 };
@@ -33,10 +32,6 @@ struct DetumbleControllerState {
  *  Essentially serves as the inputs to the control_detumble function. See
  *  member documentation for more details. */
 struct DetumbleControllerData {
-  /** Timestamp for the rest of the data in this struct and the time for which
-   *  an attitude actuation will be calculated. This should be in seconds since
-   *  the 'PAN epoch'. */
-  double t;
   /** Observed magnetic field in the body frame of the spacecraft. */
   lin::Vector3f b_body;
   /** Defaults everything's value to NaN. */

--- a/include/gnc_constants.hpp
+++ b/include/gnc_constants.hpp
@@ -137,6 +137,14 @@ constexpr static double b_noise_floor = 0.0L;
 /** Noise floor of the magnetometer in units of T (float version). */
 constexpr static float b_noise_floor_f = static_cast<float>(b_noise_floor);
 
+/** Largest magnetic moment along a single axis that can be commanded of the
+ *  ADCS system in units of Am^2. */
+constexpr static double max_mtr_moment = 0.113337L / 2.0L;  // For one MTR
+
+/** Largest magnetic moment along a single axis that can be commanded of the
+ *  ADCS system in units of Am^2 (float version). */
+constexpr static float max_mtr_moment_f = static_cast<float>(max_mtr_moment);
+
 }  // namespace constants
 }  // namespace gnc
 

--- a/src/gnc_attitude_controller.cpp
+++ b/src/gnc_attitude_controller.cpp
@@ -59,6 +59,7 @@ void control_detumble(DetumbleControllerState &state,
       constant::max_mtr_moment_f * (db(1) > 0.0f ? -1.0f : 1.0f),
       constant::max_mtr_moment_f * (db(2) > 0.0f ? -1.0f : 1.0f)
     };
+    state.b_body_buffer.clear();
   }
 
   // Assign the most recently calculated magetorquer command

--- a/src/gnc_attitude_controller.cpp
+++ b/src/gnc_attitude_controller.cpp
@@ -1,0 +1,72 @@
+//
+// src/gnc_attitude_controller.hpp
+// PSim
+//
+// Contributors:
+//   Kyle Krol  kpk63@cornell.edu
+//
+// Pathfinder for Autonomous Navigation
+// Space Systems Design Studio
+// Cornell Univeristy
+//
+
+#include <gnc_attitude_controller.hpp>
+#include <gnc_constants.hpp>
+
+#include <limits>
+
+static_assert(std::numeric_limits<double>::has_quiet_NaN,
+    "GNC code requires quiet NaN's to be available.");
+static_assert(std::numeric_limits<float>::has_quiet_NaN,
+    "GNC code requires quiet NaN's to be available.");
+
+namespace gnc {
+
+DetumbleControllerState::DetumbleControllerState() {
+  this->t = std::numeric_limits<double>::quiet_NaN();
+  this->b_body = lin::nans<decltype(this->b_body)>();
+  this->db_buffer = CircularBuffer<lin::Vector3f, 5>();
+}
+
+DetumbleControllerData::DetumbleControllerData() {
+  this->t = std::numeric_limits<double>::quiet_NaN();
+  this->b_body = lin::nans<decltype(this->b_body)>();
+}
+
+DetumbleActuation::DetumbleActuation() {
+  this->mtr_body_cmd = lin::nans<decltype(this->mtr_body_cmd)>();
+}
+
+void control_detumble(DetumbleControllerState &state,
+    DetumbleControllerData const &data, DetumbleActuation &actuation) {
+
+  // Clear the state if it's outdated (more than ~5 control cycles old)
+  if (data.t - state.t > 0.5) state = DetumbleControllerState();
+
+  // Default everything to NaN and ensure a magnetic field vector and time were
+  // given
+  if (std::isnan(data.b_body(0)) || std::isnan(data.t)) return;
+
+  // If we don't have an old estimate just write the current one into state and
+  // wait till the next call to estimate w_body
+  if (std::isnan(state.t) || std::isnan(state.b_body(0))) {
+    state.t = data.t;
+    state.b_body = data.b_body;
+  }
+
+  // Calculate db and calculate its moving average
+  lin::Vector3f db = (data.b_body - state.b_body) / (data.t - state.t);
+  state.db_buffer.push(db);
+  db = lin::zeros<float, 3, 1>();
+  for (std::size_t i = 0; i < state.db_buffer.size(); i++)
+    db = db + state.db_buffer[i];
+  db = db / static_cast<float>(state.db_buffer.size());
+
+  // Run the bang-bang controller
+  actuation.mtr_body_cmd = {
+    constant::max_mtr_moment_f * (db(0) > 0.0f ? -1.0f : 1.0f),
+    constant::max_mtr_moment_f * (db(1) > 0.0f ? -1.0f : 1.0f),
+    constant::max_mtr_moment_f * (db(2) > 0.0f ? -1.0f : 1.0f)
+  };
+}
+}  // namespace gnc


### PR DESCRIPTION
Relates to #82.

Completed the detumble attitude controller. The pointing attitude controller should be coming next! It follows the same design pattern as the attitude estimator.

One issue that is starting to crop up is the duplication of constants between common software and psim (in this PR it's the `gnc::constants::max_mtr_moment`). I think it'll be easiest to refactor ADCS Software and the ADCS driver down the line - otherwise the dependency web will start getting bit crazy. However, I won't push for this change until GNC stuff is in a more completed state (i.e. like the version 1.0 release).