### PR TITLE
Added astropy eci2ecef and ecef2eci functions

### DIFF
--- a/MATLAB/environmental_models/env_ECEFtoECIastropy.m
+++ b/MATLAB/environmental_models/env_ECEFtoECIastropy.m
@@ -1,0 +1,12 @@
+function [r_ECI,v_ECI] = env_ECEFtoECIastropy(time,r_ECEF,v_ECEF)
+%Returns a position and velocity in ECI from ECEF, units s, m, m/s
+%  The shape of the vectors should be (3,1)
+%   time(double): seconds since const.INITGPS_WN
+global const
+a=cell(py.environmental_models.helper_functions.eci_ecef_conversions.ecef2eci(time,r_ECEF,v_ECEF,const.INITGPS_WN));
+r_ECI= double(a{1})';
+v_ECI= double(a{2})';
+
+
+    
+    

--- a/MATLAB/environmental_models/env_ECItoECEFastropy.m
+++ b/MATLAB/environmental_models/env_ECItoECEFastropy.m
@@ -1,0 +1,12 @@
+function [r_ECEF,v_ECEF] = env_ECItoECEFastropy(time,r_ECI,v_ECI)
+%Returns a position and velocity in ECEF from ECI, units s, m, m/s
+%  The shape of the vectors should be (3,1)
+%   time(double): seconds since const.INITGPS_WN
+global const
+a=cell(py.environmental_models.helper_functions.eci_ecef_conversions.eci2ecef(time,r_ECI,v_ECI,const.INITGPS_WN));
+r_ECEF= double(a{1})';
+v_ECEF= double(a{2})';
+
+
+    
+    

--- a/MATLAB/environmental_models/helper_functions/eci_ecef_conversions.py
+++ b/MATLAB/environmental_models/helper_functions/eci_ecef_conversions.py
@@ -1,0 +1,41 @@
+#eci_ecef_conversions.py
+#Nathan Zimmerberg (nhz2)
+#November 24, 2019
+# using examples from https://astropy.readthedocs.io/en/latest/coordinates/velocities.html
+"""Module for using astropy to convert between ECI and ECEF coordinates and velocities"""
+import astropy.units as u
+from astropy.coordinates import (ITRS,GCRS)
+from astropy.coordinates import (CartesianRepresentation,CartesianDifferential)
+from astropy.time import TimeDelta
+from astropy.time import Time
+
+
+
+
+def time2astropyTime(time,init_gps_weeknum):
+    """
+    args:
+        time(double): time since init_GPS_week_number in seconds
+        init_gps_weeknum(int): initial GPS week number."""
+    return Time(init_gps_weeknum*7*24*60*60, time, scale='tai', format='gps')
+
+
+def ecef2eci(time,r_ecef,v_ecef,init_gps_weeknum):
+    """Returns a tuple of position and velocity in ECI"""
+    coord_ecef=ITRS(x=r_ecef[0]*u.m, y=r_ecef[1]*u.m, z=r_ecef[2]*u.m,
+        v_x=v_ecef[0]*u.m/u.s, v_y=v_ecef[1]*u.m/u.s, v_z=v_ecef[2]*u.m/u.s,
+        representation_type=CartesianRepresentation,
+        differential_type=CartesianDifferential,
+        obstime=time2astropyTime(time,init_gps_weeknum))
+    coord_eci= coord_ecef.transform_to(GCRS(obstime=time2astropyTime(time,init_gps_weeknum)))
+    return (coord_eci.cartesian.xyz.to_value(u.m),coord_eci.velocity.d_xyz.to_value(u.m/u.s))
+
+def eci2ecef(time,r_eci,v_eci,init_gps_weeknum):
+    """Returns a tuple of position and velocity in ECEF"""
+    coord_eci=GCRS(x=r_eci[0]*u.m, y=r_eci[1]*u.m, z=r_eci[2]*u.m,
+        v_x=v_eci[0]*u.m/u.s, v_y=v_eci[1]*u.m/u.s, v_z=v_eci[2]*u.m/u.s,
+        representation_type=CartesianRepresentation,
+        differential_type=CartesianDifferential,
+        obstime=time2astropyTime(time,init_gps_weeknum))
+    coord_ecef= coord_eci.transform_to(ITRS(obstime=time2astropyTime(time,init_gps_weeknum)))
+    return (coord_ecef.cartesian.xyz.to_value(u.m),coord_ecef.velocity.d_xyz.to_value(u.m/u.s))


### PR DESCRIPTION
To run this I had to install astropy, using the command `conda install astropy` in terminal.

Then in MATLAB, I had to run `pyenv('Version','/anaconda3/bin/python')` after restarting matlab. 

To find where your python is, on mac you can use the command `which python` in terminal. Use the result of that instead of `'/anaconda3/bin/python'` in the `pyenv`. I have no idea if this will work on windows.

Using these functions the true orbit propagator got within 1m of the grace data for one orbit, using the third body and 35x35 gravity model.