### PR TITLE
Install script

### DIFF
--- a/MATLAB/README.md
+++ b/MATLAB/README.md
@@ -373,6 +373,11 @@ One the Matlab simulation side, next getting a complete version of `sensor_readi
 | plot_orbit_error             | Nathan  |          | done                 | NA          | NA          |
 | plot_fancy_animation         | Nathan  |          | done                 | NA          | NA          |
 
+# Installation
+1. Install MATLAB R2019b, Matlab Add-Ons, and ensure you have a C++ compiler by running `mex -setup C++`
+2. Run `install.m` script to compile all C code into mex.
+
+Run `install.m` everytime you reclone or redownload the repo. 
 
 ## Matlab Add-Ons
 
@@ -383,5 +388,3 @@ There are a few required Add-Ons for Matlab
  * Aerospace Toolbox
  * Robotics System Toolbox
  * Convert between RGB and Color Names
-
-In addition a C++ compiler is need, in matlab run `mex -setup C++` to ensure you have one.

--- a/MATLAB/config.m
+++ b/MATLAB/config.m
@@ -7,15 +7,7 @@ Script to initialize const global variables.
 %}
 global const
 
-[filepath, name, ext] = fileparts(mfilename("fullpath"));
-addpath(strcat(filepath, '/utl'));
-addpath(strcat(filepath, '/environmental_models'));
-addpath(strcat(filepath, '/environmental_models/helper_functions'));
-addpath(strcat(filepath, '/plot'));
-addpath(strcat(filepath, '/plot/czml_helpers'));
-addpath(strcat(filepath, '/adcs'));
-addpath(strcat(filepath, '/orbit_estimation'));
-addpath(strcat(filepath, '/test'));
+setup_path()
 
 
 %Time

--- a/MATLAB/install.m
+++ b/MATLAB/install.m
@@ -1,0 +1,5 @@
+%Script to compile everything, and get data files, only call this on fresh
+%installs, or if you want to refresh everything.
+setup_path();
+%compile everything
+generate_mex_code();

--- a/MATLAB/setup_path.m
+++ b/MATLAB/setup_path.m
@@ -1,0 +1,3 @@
+%Script to setup the matlab path.
+[filepath, name, ext] = fileparts(mfilename("fullpath"));
+addpath(genpath(filepath));


### PR DESCRIPTION
I moved the MATLAB C++ code compilation to an `install.m` script. Right now it is optional to run `install.m` because C++ code compilation also happens in `config.m` but in a future PR `config.m` will not do C++ code compilation. 

The reason for this change is 
1. I am adding in [USNavalResearchLaboratory/TrackerComponentLibrary](https://github.com/USNavalResearchLaboratory/TrackerComponentLibrary) which has a huge amount of installation and C++ code compilation, 
2. When running in multiple sims in parallel, if `config.m` writes to shared files by recompiling code that another worker is using, it causes an error.

Ideally the script would somehow use makefiles or something to only recompile C++ code that has changed, but I am not sure how to do this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pathfinder-for-autonomous-navigation/psim/138)
<!-- Reviewable:end -->
