### PR TITLE
Add CXX Attitude Controller

### DIFF
--- a/include/gnc/attitude_controller.hpp
+++ b/include/gnc/attitude_controller.hpp
@@ -64,19 +64,19 @@ struct PointingControllerState {
  *  objective information) as NaNs. See member documentation for more details.
  *  */
 struct PointingControllerData {
-  /** Desired state of the primary pointing objective. This needs to be a unit
-   *  vector. */
+  /** Desired state of the primary pointing objective in the body frame. This
+   *  needs to be a unit vector. */
   lin::Vector3f primary_desired;
-  /** Current state of the primary pointing objective. This needs to be a unit
-   *  vector. */
+  /** Current state of the primary pointing objective in the body frame. This
+   *  needs to be a unit vector. */
   lin::Vector3f primary_current;
-  /** Desired state of the secondary pointing objective. This needs to be a unit
-   *  vector. */
+  /** Desired state of the secondary pointing objective in the body frame. This
+   *  needs to be a unit vector. */
   lin::Vector3f secondary_desired;
-  /** Current state of the secondary pointing objective. This needs to be a unit
-   *  vector. */
+  /** Current state of the secondary pointing objective in the body frame. This
+   *  needs to be a unit vector. */
   lin::Vector3f secondary_current;
-  /** Angular rate of the wheels in the body frame (units of radians/s) */
+  /** Angular rate of the wheels in the body frame (units of radians/s). */
   lin::Vector3f w_wheels;
   /** Angular rate of the satellite in the body frame (units of radians/s). */
   lin::Vector3f w_sat;
@@ -90,9 +90,9 @@ struct PointingControllerData {
  *  Essentially serves as the outputs to the control_pointing function. See
  *  member documentation for more information. */
 struct PointingActuation {
-  /** Magnetourquer actuation command in the body frame (units Am^2) */
+  /** Magnetourquer actuation command in the body frame (units Am^2). */
   lin::Vector3f mtr_body_cmd;
-  /** Reaction wheel torque command in the body frame (units Nm) */
+  /** Reaction wheel torque command in the body frame (units Nm). */
   lin::Vector3f rwa_body_cmd;
   /** Defaults everything's value to NaN. */
   PointingActuation();

--- a/include/gnc/attitude_controller.hpp
+++ b/include/gnc/attitude_controller.hpp
@@ -104,8 +104,17 @@ struct PointingActuation {
  *  @param[out]   actuation Controller's outputs.
  *  Calculates wheel and MTR actuations to point to spacecraft according to the
  *  passed objectives. */
+#ifndef MEX
 void control_pointing(PointingControllerState &state,
     PointingControllerData const &data, PointingActuation &actuation);
+#else
+/** @fn mex_control_pointing
+ *  Mex function entrypoint for MATLAB use. It decouples the pointing controller
+ *  from the global controller gains and satellite's moment of inertia value. */
+void mex_control_pointing(control_pointing(PointingControllerState &state,
+    PointingControllerData const &data, PointingActuation &actuation, float Kp,
+    float Kd, lin::Matrix3x3f const &J);
+#endif
 
 }  // namespace gnc
 

--- a/include/gnc/attitude_controller.hpp
+++ b/include/gnc/attitude_controller.hpp
@@ -5,6 +5,7 @@
 #ifndef GNC_ATTITUDE_CONTROLLER_HPP_
 #define GNC_ATTITUDE_CONTROLLER_HPP_
 
+#include "config.hpp"
 #include "containers.hpp"
 
 #include <lin/core.hpp>
@@ -48,6 +49,24 @@ struct DetumbleActuation {
  *  @param[out]   actuation Actuation output. */
 void control_detumble(DetumbleControllerState &state,
     DetumbleControllerData const &data, DetumbleActuation &actuation);
+
+struct PointingControllerState {
+  /** Defaults everything's value to NaN. */
+  PointingControllerState();
+};
+
+struct PointingControllerData {
+  /** Defaults everything's value to NaN. */
+  PointingControllerData();
+};
+
+struct PointingActuation {
+  /** Defaults everything's value to NaN. */
+  PointingActuation();
+};
+
+void control_pointing(PointingControllerState &state,
+    PointingControllerData const &data, PointingActuation &actuation);
 
 }  // namespace gnc
 

--- a/include/gnc/attitude_controller.hpp
+++ b/include/gnc/attitude_controller.hpp
@@ -36,17 +36,17 @@ struct DetumbleControllerData {
  *  Essentially serves as the outputs to the control_detumble function. See
  *  member documentation for more details. */
 struct DetumbleActuation {
-  /** Magnetourquer actuation command in the body frame (units Am^2) */
+  /** Magnetourquer actuation command in the body frame (units Am^2). */
   lin::Vector3f mtr_body_cmd;
   /** Defaults everything's value to NaN. */
   DetumbleActuation();
 };
 
 /** @fn control_detumble
- *  @brief Calculation MTR actuations to detumble the spacecraft.
  *  @param[inout] state     Control function internal state information.
  *  @param[in]    data      Control function inputs
- *  @param[out]   actuation Actuation output. */
+ *  @param[out]   actuation Actuation output.
+ *  Calculation MTR actuations to detumble the spacecraft. */
 void control_detumble(DetumbleControllerState &state,
     DetumbleControllerData const &data, DetumbleActuation &actuation);
 
@@ -58,6 +58,24 @@ struct PointingControllerState {
 
 /** @struct PointingControllerData */
 struct PointingControllerData {
+  /** Desired state of the primary pointing objective. This needs to be a unit
+   *  vector. */
+  lin::Vector3f primary_desired;
+  /** Current state of the primary pointing objective. This needs to be a unit
+   *  vector. */
+  lin::Vector3f primary_current;
+  /** Desired state of the secondary pointing objective. This needs to be a unit
+   *  vector. */
+  lin::Vector3f secondary_desired;
+  /** Current state of the secondary pointing objective. This needs to be a unit
+   *  vector. */
+  lin::Vector3f secondary_current;
+  /** Angular rate of the wheels in the body frame (units of radians/s) */
+  lin::Vector3f w_wheels;
+  /** Angular rate of the satellite in the body frame (units of radians/s). */
+  lin::Vector3f w_sat;
+  /** Magnetic field in the body frame (units of T). */
+  lin::Vector3f b;
   /** Defaults everything's value to NaN. */
   PointingControllerData();
 };

--- a/include/gnc/attitude_controller.hpp
+++ b/include/gnc/attitude_controller.hpp
@@ -98,13 +98,13 @@ struct PointingActuation {
   PointingActuation();
 };
 
+#ifndef MEX
 /** @fn control_pointing
  *  @param[inout] state     Controller's internal state information.
  *  @param[in]    data      Controller's inputs.
  *  @param[out]   actuation Controller's outputs.
  *  Calculates wheel and MTR actuations to point to spacecraft according to the
  *  passed objectives. */
-#ifndef MEX
 void control_pointing(PointingControllerState &state,
     PointingControllerData const &data, PointingActuation &actuation);
 #else

--- a/include/gnc/attitude_controller.hpp
+++ b/include/gnc/attitude_controller.hpp
@@ -50,17 +50,24 @@ struct DetumbleActuation {
 void control_detumble(DetumbleControllerState &state,
     DetumbleControllerData const &data, DetumbleActuation &actuation);
 
+/** @struct PointingControllerState */
 struct PointingControllerState {
   /** Defaults everything's value to NaN. */
   PointingControllerState();
 };
 
+/** @struct PointingControllerData */
 struct PointingControllerData {
   /** Defaults everything's value to NaN. */
   PointingControllerData();
 };
 
+/** @struct PointingActuation */
 struct PointingActuation {
+  /** Magnetourquer actuation command in the body frame (units Am^2) */
+  lin::Vector3f mtr_body_cmd;
+  /** Reaction wheel torque command in the body frame (units Nm) */
+  lin::Vector3f rwa_body_cmd;
   /** Defaults everything's value to NaN. */
   PointingActuation();
 };

--- a/include/gnc/attitude_controller.hpp
+++ b/include/gnc/attitude_controller.hpp
@@ -43,20 +43,26 @@ struct DetumbleActuation {
 };
 
 /** @fn control_detumble
- *  @param[inout] state     Control function internal state information.
- *  @param[in]    data      Control function inputs
- *  @param[out]   actuation Actuation output.
+ *  @param[inout] state     Controller's internal state information.
+ *  @param[in]    data      Controller's inputs.
+ *  @param[out]   actuation Controller's outputs.
  *  Calculation MTR actuations to detumble the spacecraft. */
 void control_detumble(DetumbleControllerState &state,
     DetumbleControllerData const &data, DetumbleActuation &actuation);
 
-/** @struct PointingControllerState */
+/** @struct PointingControllerState
+ *  Contains internal state information needed by the control_pointing function.
+ *  */
 struct PointingControllerState {
   /** Defaults everything's value to NaN. */
   PointingControllerState();
 };
 
-/** @struct PointingControllerData */
+/** @struct PointingControllerData
+ *  Essentially serves as the inputs to the control_pointing function. Note,
+ *  it is permissable to leave some members (like the secondary pointing
+ *  objective information) as NaNs. See member documentation for more details.
+ *  */
 struct PointingControllerData {
   /** Desired state of the primary pointing objective. This needs to be a unit
    *  vector. */
@@ -80,7 +86,9 @@ struct PointingControllerData {
   PointingControllerData();
 };
 
-/** @struct PointingActuation */
+/** @struct PointingActuation
+ *  Essentially serves as the outputs to the control_pointing function. See
+ *  member documentation for more information. */
 struct PointingActuation {
   /** Magnetourquer actuation command in the body frame (units Am^2) */
   lin::Vector3f mtr_body_cmd;
@@ -90,6 +98,12 @@ struct PointingActuation {
   PointingActuation();
 };
 
+/** @fn control_pointing
+ *  @param[inout] state     Controller's internal state information.
+ *  @param[in]    data      Controller's inputs.
+ *  @param[out]   actuation Controller's outputs.
+ *  Calculates wheel and MTR actuations to point to spacecraft according to the
+ *  passed objectives. */
 void control_pointing(PointingControllerState &state,
     PointingControllerData const &data, PointingActuation &actuation);
 

--- a/include/gnc/config.hpp
+++ b/include/gnc/config.hpp
@@ -6,6 +6,7 @@
 #ifndef GNC_CONFIG_HPP_
 #define GNC_CONFIG_HPP_
 
+#include <cmath>
 #include <limits>
 #include <type_traits>
 
@@ -21,6 +22,10 @@
 #else
   #define GNC_ASSERT(x)
 #endif
+
+/** Assert some number is near another within some tolerance. This should be
+ *  used with floating point values. */
+#define GNC_ASSERT_NEAR(a, b, delta) GNC_ASSERT(std::abs(a - b) < delta)
 
 /* Ensure float literals are actually floats and double literals are actually
  * doubles. */

--- a/include/gnc/constants.hpp
+++ b/include/gnc/constants.hpp
@@ -15,7 +15,23 @@ namespace constant {
 
 GNC_TRACKED_CONSTANT(constexpr static double, pi, 3.141592653589793);
 
+GNC_TRACKED_CONSTANT(constexpr static float, pi_f, pi);
+
 GNC_TRACKED_CONSTANT(constexpr static double, two_pi, 2.0 * pi);
+
+GNC_TRACKED_CONSTANT(constexpr static float, two_pi_f, two_pi);
+
+GNC_TRACKED_CONSTANT(constexpr static double, deg_to_rad, pi / 180.0);
+
+GNC_TRACKED_CONSTANT(constexpr static float, deg_to_rad_f, deg_to_rad);
+
+GNC_TRACKED_CONSTANT(constexpr static double, rad_to_deg, 180.0 / pi);
+
+GNC_TRACKED_CONSTANT(constexpr static float, rad_to_deg_f, rad_to_deg);
+
+GNC_TRACKED_CONSTANT(constexpr static double, mu_earth, 3.986004418e14);
+
+GNC_TRACKED_CONSTANT(constexpr static float, mu_earth_f, mu_earth);
 
 extern unsigned short init_gps_week_number;
 
@@ -43,9 +59,15 @@ GNC_TRACKED_CONSTANT(constexpr static double, b_noise_floor, 0.0);
 
 GNC_TRACKED_CONSTANT(constexpr static double, max_mtr_moment, 0.113337 / 2.0);
 
-GNC_TRACKED_CONSTANT(constexpr static lin::Matrix3x3f, JB_single_sat, 0.03798, 0.0, 0.0, 0.0, 0.03957, 0.0, 0.0, 0.0, 0.00688);
+extern lin::Matrix3x3f J_sat;
 
-GNC_TRACKED_CONSTANT(constexpr static lin::Matrix3x3f, JB_docked_sats, 0.03798, 0.0, 0.0, 0.0, 0.03957, 0.0, 0.0, 0.0, 0.00688);
+extern float pointer_Kp;
+
+extern float pointer_Kd;
+
+GNC_TRACKED_CONSTANT(constexpr static float, J_wheel, 135.0e-7f);
+
+GNC_TRACKED_CONSTANT(constexpr static float, w_wheel_max, 677.0f);
 
 }  // namespace constant
 }  // namespace gnc

--- a/src/gnc_attitude_controller.cpp
+++ b/src/gnc_attitude_controller.cpp
@@ -157,6 +157,9 @@ void control_pointing(PointingControllerState &state,
   // Total angular momentum of the satellite in the body frame
   L = constant::J_sat * data.w_sat + constant::J_wheel * data.w_wheels;
 
+  // Total angular momentum should never be NaN here
+  GNC_ASSERT(!std::isnan(L(0)));
+
   // Magnitude of L calls for momentum control
   if (lin::norm(L) > 0.05f * constant::w_wheel_max * constant::J_wheel) {
     L = lin::cross(L, data.b);

--- a/src/gnc_attitude_controller.cpp
+++ b/src/gnc_attitude_controller.cpp
@@ -1,12 +1,16 @@
 /** @file gnc_attitude_controller.cpp
- *  @author Kyle Krol */
+ *  @author Kyle Krol
+ *  See MATLAB/adcs/adcs_pointer.c and MATLAB/adcs/adcs_detumbler.m for more
+ *  information. */
 
 #include <gnc/attitude_controller.hpp>
-#include <gnc/config.hpp>
 #include <gnc/constants.hpp>
+#include <gnc/utilities.hpp>
 
 #include <lin/generators/constants.hpp>
+#include <lin/references.hpp>
 
+#include <cmath>
 #include <limits>
 
 namespace gnc {
@@ -53,6 +57,116 @@ void control_detumble(DetumbleControllerState &state,
 
   // Assign the most recently calculated magetorquer command
   actuation.mtr_body_cmd = state.mtr_body_cmd;
+
+}
+
+PointingControllerState::PointingControllerState() { }
+
+PointingControllerData::PointingControllerData()
+: primary_desired(lin::nans<decltype(primary_desired)>()),
+  primary_current(lin::nans<decltype(primary_current)>()),
+  secondary_desired(lin::nans<decltype(secondary_desired)>()),
+  secondary_current(lin::nans<decltype(secondary_current)>()),
+  w_wheels(lin::nans<decltype(w_wheels)>()),
+  w_sat(lin::nans<decltype(w_sat)>()),
+  b(lin::nans<decltype(b)>()) { }
+
+PointingActuation::PointingActuation()
+: mtr_body_cmd(lin::nans<decltype(mtr_body_cmd)>()),
+  rwa_body_cmd(lin::nans<decltype(rwa_body_cmd)>()) { }
+
+static void error_from_quaternion(lin::Vector4f const &q, lin::Vector3f &err) {
+  if (q(3) < 0.0f) err = -lin::ref<3, 1>(q, 0, 0);
+  else err = lin::ref<3, 1>(q, 0, 0);
+}
+
+static void double_objective_error(
+    lin::Vector3f const &pri_cur, lin::Vector3f const &pri_des,
+    lin::Vector3f const &sec_cur, lin::Vector3f const &sec_des,
+    lin::Vector3f &err) {
+  lin::Vector4f q;
+
+  // Ensure we are dealing with normal vectors
+  GNC_ASSERT_NEAR(1.0f, lin::fro(pri_cur), 1.0e-5f);
+  GNC_ASSERT_NEAR(1.0f, lin::fro(pri_des), 1.0e-5f);
+  GNC_ASSERT_NEAR(1.0f, lin::fro(sec_cur), 1.0e-5f);
+  GNC_ASSERT_NEAR(1.0f, lin::fro(sec_des), 1.0e-5f);
+
+  // Calculate attitude error quaternion using triad and extract error term
+  utl::triad(pri_cur, sec_cur, pri_des, sec_des, q);
+  error_from_quaternion(q, err);
+}
+
+static void single_objective_error(
+    lin::Vector3f const &pri_cur, lin::Vector3f const &pri_des,
+    lin::Vector3f &err) {
+  lin::Vector4f q;
+
+  // Ensure we are dealing with normal vectors
+  GNC_ASSERT_NEAR(1.0f, lin::fro(pri_cur), 1.0e-5f);
+  GNC_ASSERT_NEAR(1.0f, lin::fro(pri_des), 1.0e-5f);
+
+  // Calculate attitude error quaternion and extract error term
+  // Note we have a degree of freedom here that's ignored
+  utl::vec_rot_to_quat(pri_des, pri_cur, q);
+  error_from_quaternion(q, err);
+}
+
+constexpr float sign(float val) {
+    return static_cast<float>((0.0f < val) - (val < 0.0f));
+}
+
+void control_pointing(PointingControllerState &state,
+    PointingControllerData const &data, PointingActuation &actuation) {
+  lin::Vector3f err, L;
+
+  // Default everything to NaN
+  actuation = PointingActuation();
+
+  // We need a primary pointing objective and current angular rate at the very
+  // least
+  if (std::isnan(data.primary_current(0)) ||
+      std::isnan(data.primary_desired(0)) || std::isnan(data.w_sat(0)))
+    return;
+
+  // No secondary objective is specified
+  if (std::isnan(data.secondary_current(0)) ||
+      std::isnan(data.secondary_desired(0))) {
+    single_objective_error(data.primary_current, data.primary_desired, err);
+  }
+  // Secondary objective is specified
+  else {
+    // Check is the primary and secondary objectives are too near
+    if (true)
+      single_objective_error(data.primary_current, data.primary_desired, err);
+    else
+      double_objective_error(data.primary_current, data.primary_desired,
+          data.secondary_current, data.secondary_desired, err);
+  }
+
+  // Error term should never be NaN here
+  GNC_ASSERT(!std::isnan(err(0)));
+
+  // Determine the wheel actation
+  actuation.rwa_body_cmd = -(constant::pointer_Kp * err + constant::pointer_Kd * data.w_sat);
+
+  // Ensure we have wheel speed data and a magnetic field to perform angular
+  // momentum control with
+  if (std::isnan(data.w_wheels(0)) || std::isnan(data.b(0))) return;
+
+  // Total angular momentum of the satellite in the body frame
+  L = constant::J_sat * data.w_sat + constant::J_wheel * data.w_wheels;
+
+  // Magnitude of L calls for momentum control
+  if (lin::norm(L) > 0.05f * constant::w_wheel_max * constant::J_wheel) {
+    L = lin::cross(L, data.b);
+    actuation.mtr_body_cmd = constant::max_mtr_moment * lin::Vector3f({
+      sign(L(0)), sign(L(1)), sign(L(2)), 
+    });
+  }
+  // No momentum control required at this time
+  else
+    actuation.mtr_body_cmd = lin::zeros<decltype(actuation.mtr_body_cmd)>();
 
 }
 }  // namespace gnc

--- a/src/gnc_attitude_controller.cpp
+++ b/src/gnc_attitude_controller.cpp
@@ -118,7 +118,6 @@ constexpr float sign(float val) {
 
 void control_pointing(PointingControllerState &state,
     PointingControllerData const &data, PointingActuation &actuation) {
-  lin::Vector3f err, L;
 
   // Default everything to NaN
   actuation = PointingActuation();
@@ -130,6 +129,7 @@ void control_pointing(PointingControllerState &state,
     return;
 
   // No secondary objective is specified
+  lin::Vector3f err;
   if (std::isnan(data.secondary_current(0)) ||
       std::isnan(data.secondary_desired(0))) {
     single_objective_error(data.primary_current, data.primary_desired, err);
@@ -137,7 +137,9 @@ void control_pointing(PointingControllerState &state,
   // Secondary objective is specified
   else {
     // Check is the primary and secondary objectives are too near
-    if (true)
+    float thresh = std::cos(10.0f * constant::pi_f / 180.0f);  // within 10 deg.
+    if (std::abs(lin::dot(data.secondary_current, data.primary_current)) < thresh ||
+        std::abs(lin::dot(data.secondary_desired, data.primary_desired)) < thresh)
       single_objective_error(data.primary_current, data.primary_desired, err);
     else
       double_objective_error(data.primary_current, data.primary_desired,
@@ -155,7 +157,7 @@ void control_pointing(PointingControllerState &state,
   if (std::isnan(data.w_wheels(0)) || std::isnan(data.b(0))) return;
 
   // Total angular momentum of the satellite in the body frame
-  L = constant::J_sat * data.w_sat + constant::J_wheel * data.w_wheels;
+  lin::Vector3f L = constant::J_sat * data.w_sat + constant::J_wheel * data.w_wheels;
 
   // Total angular momentum should never be NaN here
   GNC_ASSERT(!std::isnan(L(0)));

--- a/src/gnc_constants.cpp
+++ b/src/gnc_constants.cpp
@@ -22,6 +22,12 @@ GNC_TRACKED_CONSTANT(lin::Vector3d, earth_precession_rate, 1.0e-11 * 0.069896936
 
 GNC_TRACKED_CONSTANT(lin::Vector4d, q_ecef0_eci, 0.000917219458782, 0.000038843277811, 0.998612074831165, 0.052660053181324);
 
+GNC_TRACKED_CONSTANT(lin::Matrix3x3f, J_sat, 0.03798, 0.0, 0.0, 0.0, 0.03957, 0.0, 0.0, 0.0, 0.00688);
+
+GNC_TRACKED_CONSTANT(float, pointer_Kp, 20.0e-4f);
+
+GNC_TRACKED_CONSTANT(float, pointer_Kd, 22.5e-4f);
+
 }  // namespace constant
 }  // namespace gnc
 

--- a/tools/constants.csv
+++ b/tools/constants.csv
@@ -1,5 +1,13 @@
 false,double,pi,3.141592653589793
+false,float,pi_f,pi
 false,double,two_pi,2.0 * pi
+false,float,two_pi_f,two_pi
+false,double,deg_to_rad,pi / 180.0
+false,float,deg_to_rad_f,deg_to_rad
+false,double,rad_to_deg,180.0 / pi
+false,float,rad_to_deg_f,rad_to_deg
+false,double,mu_earth,3.986004418e14
+false,float,mu_earth_f,mu_earth
 true,unsigned short,init_gps_week_number,2045
 true,unsigned int,init_gps_time_of_week,0
 true,unsigned long,init_gps_nanoseconds,0
@@ -13,5 +21,8 @@ false,double,earth_period,365.256363004 * 24.0 * 60.0 * 60.0
 false,lin::Vector4d,q_eci_perifocal,0.127456632677880,-0.158124280715206,0.762378784011859,-0.614434787689722
 false,double,b_noise_floor,0.0
 false,double,max_mtr_moment,0.113337 / 2.0
-false,lin::Matrix3x3f,JB_single_sat,0.03798,0.0,0.0,0.0,0.03957,0.0,0.0,0.0,0.00688
-false,lin::Matrix3x3f,JB_docked_sats,0.03798,0.0,0.0,0.0,0.03957,0.0,0.0,0.0,0.00688
+true,lin::Matrix3x3f,J_sat,0.03798,0.0,0.0,0.0,0.03957,0.0,0.0,0.0,0.00688
+true,float,pointer_Kp,20.0e-4f
+true,float,pointer_Kd,22.5e-4f
+false,float,J_wheel,135.0e-7f
+false,float,w_wheel_max,677.0f


### PR DESCRIPTION
# CXX Attitude Controller

Fixes #82.

### Summary of changes

- Added the CXX pointing controller interface and implementation.
- Added necessary and additional, helpful constants.

### Ptest Effects

NA.

### Testing

This will be deferred to a future PR. I am going to opening an issue and working on replacing our current MATLAB controller with this CXX implementation and getting a HOOTL case with attitude control hopefully running soon.

### Constants

MATLAB constants weren't touched.

As for the CXX constants, we will need to come up with some location to document the constants and make it very clear to flight software what changing some of the externs' values will do - i.e. ~~right now to configure the pointing controller flight software would, in theory, change the controller's gains and the satellite's moment of inertia matrix once we dock~~ we may make edits to gains, moment intertia measurements, etc from the ground whether this be in the middle of the mission due to off nominal behavior or once we have docked and want to enable ADCS again.

### Documentation Evidence

See inline documentation for the time being.