### PR TITLE
Added NaN Constants

### DIFF
--- a/include/gnc/constants.hpp
+++ b/include/gnc/constants.hpp
@@ -10,6 +10,8 @@
 #include <lin/core/matrix/matrix.hpp>
 #include <lin/core/vector/vector.hpp>
 
+#include <limits>
+
 namespace gnc {
 namespace constant {
 

--- a/include/gnc/constants.hpp
+++ b/include/gnc/constants.hpp
@@ -33,6 +33,10 @@ GNC_TRACKED_CONSTANT(constexpr static double, mu_earth, 3.986004418e14);
 
 GNC_TRACKED_CONSTANT(constexpr static float, mu_earth_f, mu_earth);
 
+GNC_TRACKED_CONSTANT(constexpr static double, nan, std::numeric_limits<double>::quiet_NaN());
+
+GNC_TRACKED_CONSTANT(constexpr static float, nan_f, std::numeric_limits<float>::quiet_NaN());
+
 extern unsigned short init_gps_week_number;
 
 extern unsigned int init_gps_time_of_week;

--- a/tools/constants.csv
+++ b/tools/constants.csv
@@ -8,6 +8,8 @@ false,double,rad_to_deg,180.0 / pi
 false,float,rad_to_deg_f,rad_to_deg
 false,double,mu_earth,3.986004418e14
 false,float,mu_earth_f,mu_earth
+false,double,nan,std::numeric_limits<double>::quiet_NaN()
+false,float,nan_f,std::numeric_limits<float>::quiet_NaN()
 true,unsigned short,init_gps_week_number,2045
 true,unsigned int,init_gps_time_of_week,0
 true,unsigned long,init_gps_nanoseconds,0

--- a/tools/constants_generator.py
+++ b/tools/constants_generator.py
@@ -16,6 +16,8 @@ HPP_HEADER='''\
 #include <lin/core/matrix/matrix.hpp>
 #include <lin/core/vector/vector.hpp>
 
+#include <limits>
+
 namespace gnc {
 namespace constant {
 


### PR DESCRIPTION
# Added NaN Constants

### Summary of changes
- Added two constants for float and double NaN values (`nan_f` and `nan`)

Motivated because I noticed this constant came up in flight software is a few places so I just standardized it here.

### Ptest Effects

NA

### Testing

NA

### Constants

| Constant                 | Location             | Added to review?   |
|--------------------------|----------------------|--------------------|
|         nan                |        tools/constants.csv              | :x: : trivial constant |
|         nan_f             |           tools/constants.csv           | :x: : trivial constant   |


### Documentation Evidence

NA
