### PR TITLE
Added Vector Based DCM Generation Function

### DIFF
--- a/include/gnc/inl/utilities.inl
+++ b/include/gnc/inl/utilities.inl
@@ -3,6 +3,11 @@
 
 #include "../utilities.hpp"
 
+#include <lin/core.hpp>
+#include <lin/generators/constants.hpp>
+#include <lin/math.hpp>
+#include <lin/queries.hpp>
+
 namespace gnc {
 namespace utl {
 
@@ -44,7 +49,7 @@ template <typename T>
 constexpr void dcm(lin::Matrix<T, 3, 3> &DCM, lin::Vector<T, 3> const &x,
     lin::Vector<T, 3> const &y) {
   // Check if x and y are parallel or antiparallel
-  if (std::abs(lin::dot(x / lin::norm(x), y / lin::norm(y))) > 0.999) {
+  if (std::abs(lin::dot(x / lin::norm(x), y / lin::norm(y))) > T(0.999)) {
     DCM = lin::nans<lin::Matrix<T, 3, 3>>();
     return;
   }
@@ -158,7 +163,7 @@ constexpr void triad(lin::Vector<T, 3> const &R1, lin::Vector<T, 3> const &R2,
 
   // Ensure that sun and magnetic field vectors aren't parallel or anitparallel
   T thresh = std::cos(1.0f * constant::deg_to_rad);
-  if ((lin::dot(R1, R2) > thresh) || (lin::dot(r1, r2) > thresh))
+  if ((lin::abs(lin::dot(R1, R2)) > thresh) || (lin::abs(lin::dot(r1, r2)) > thresh))
     return;
 
   // Calculate right handed bases for the known frame

--- a/include/gnc/inl/utilities.inl
+++ b/include/gnc/inl/utilities.inl
@@ -43,6 +43,12 @@ constexpr void rotate_frame(lin::Vector<T, 4> const &q, lin::Vector<T, 3> &v) {
 template <typename T>
 constexpr void dcm(lin::Matrix<T, 3, 3> &DCM, lin::Vector<T, 3> const &x,
     lin::Vector<T, 3> const &y) {
+  // Check if x and y are parallel or antiparallel
+  if (std::abs(lin::dot(x / lin::norm(x), y / lin::norm(y))) > 0.999) {
+    DCM = lin::nans<lin::Matrix<T, 3, 3>>();
+    return;
+  }
+
   // Generate references to our unit vector destinations
   auto x_hat = lin::ref_row(DCM, 0);
   auto y_hat = lin::ref_row(DCM, 1);

--- a/include/gnc/inl/utilities.inl
+++ b/include/gnc/inl/utilities.inl
@@ -40,25 +40,52 @@ constexpr void rotate_frame(lin::Vector<T, 4> const &q, lin::Vector<T, 3> &v) {
   rotate_frame(q, v, v);
 }
 
+template <typename T>
+constexpr void dcm(lin::Matrix<T, 3, 3> &DCM, lin::Vector<T, 3> const &x,
+    lin::Vector<T, 3> const &y) {
+  // Generate references to our unit vector destinations
+  auto x_hat = lin::ref_row(DCM, 0);
+  auto y_hat = lin::ref_row(DCM, 1);
+  auto z_hat = lin::ref_row(DCM, 2);
+  // Set x_hat in place
+  x_hat = lin::transpose(x);
+  x_hat = x_hat / lin::norm(x_hat);
+  // Set y_hat in place
+  y_hat = lin::transpose(y);
+  y_hat = y_hat - x_hat * lin::dot(x_hat, y_hat);
+  y_hat = y_hat / lin::norm(y_hat);
+  // Set z_hat in place
+  z_hat = lin::cross(x_hat, y_hat);
+
+  // Assert that DCM is a direction cosine matrix
+  GNC_ASSERT_NORMALIZED(lin::ref_col(DCM, 0));
+  GNC_ASSERT_NORMALIZED(lin::ref_col(DCM, 1));
+  GNC_ASSERT_NORMALIZED(lin::ref_col(DCM, 2));
+  GNC_ASSERT_NEAR(0.0f, lin::dot(lin::ref_col(DCM, 0), lin::ref_col(DCM, 1)), 1.0e-3f);
+  GNC_ASSERT_NEAR(0.0f, lin::dot(lin::ref_col(DCM, 0), lin::ref_col(DCM, 2)), 1.0e-3f);
+  GNC_ASSERT_NEAR(0.0f, lin::dot(lin::ref_col(DCM, 1), lin::ref_col(DCM, 2)), 1.0e-3f);
+}
+
 // TODO : Potentially add diagonal references to lin
 template <typename T>
-inline void dcm_to_quat(lin::Matrix<T, 3, 3> const &M, lin::Vector<T, 4> &q) {
-  // Assert that M is a direction cosine matrix
-  GNC_ASSERT_NORMALIZED(lin::ref_col(M, 0));
-  GNC_ASSERT_NORMALIZED(lin::ref_col(M, 1));
-  GNC_ASSERT_NORMALIZED(lin::ref_col(M, 2));
-  GNC_ASSERT_NEAR(0.0f, lin::dot(lin::ref_col(M, 0), lin::ref_col(M, 1)), 1.0e-3f);
-  GNC_ASSERT_NEAR(0.0f, lin::dot(lin::ref_col(M, 0), lin::ref_col(M, 2)), 1.0e-3f);
-  GNC_ASSERT_NEAR(0.0f, lin::dot(lin::ref_col(M, 1), lin::ref_col(M, 2)), 1.0e-3f);
+constexpr void dcm_to_quat(lin::Matrix<T, 3, 3> const &DCM,
+    lin::Vector<T, 4> &q) {
+  // Assert that DCM is a direction cosine matrix
+  GNC_ASSERT_NORMALIZED(lin::ref_col(DCM, 0));
+  GNC_ASSERT_NORMALIZED(lin::ref_col(DCM, 1));
+  GNC_ASSERT_NORMALIZED(lin::ref_col(DCM, 2));
+  GNC_ASSERT_NEAR(0.0f, lin::dot(lin::ref_col(DCM, 0), lin::ref_col(DCM, 1)), 1.0e-3f);
+  GNC_ASSERT_NEAR(0.0f, lin::dot(lin::ref_col(DCM, 0), lin::ref_col(DCM, 2)), 1.0e-3f);
+  GNC_ASSERT_NEAR(0.0f, lin::dot(lin::ref_col(DCM, 1), lin::ref_col(DCM, 2)), 1.0e-3f);
 
   // Find the maximum among the diagonal elements and trace
-  T max = M(0, 0);
-  T trace = M(0, 0);
+  T max = DCM(0, 0);
+  T trace = DCM(0, 0);
   lin::size_t idx = 0;
   for (lin::size_t i = 1; i < 3; i++) {
-    trace += M(i, i);
-    if (M(i, i) > max) {
-      max = M(i, i);
+    trace += DCM(i, i);
+    if (DCM(i, i) > max) {
+      max = DCM(i, i);
       idx = i;
     }
   }
@@ -73,35 +100,35 @@ inline void dcm_to_quat(lin::Matrix<T, 3, 3> const &M, lin::Vector<T, 4> &q) {
     case 0:
       q = {
         static_cast<T>(2.0) * max - trace + static_cast<T>(1.0),
-        M(0, 1) + M(1, 0),
-        M(0, 2) + M(2, 0),
-        M(1, 2) - M(2, 1)
+        DCM(0, 1) + DCM(1, 0),
+        DCM(0, 2) + DCM(2, 0),
+        DCM(1, 2) - DCM(2, 1)
       };
       break;
     // Max was M(1, 1)
     case 1:
       q = {
-        M(1, 0) + M(0, 1),
+        DCM(1, 0) + DCM(0, 1),
         static_cast<T>(2.0) * max - trace + static_cast<T>(1.0),
-        M(1, 2) + M(2, 1),
-        M(2, 0) - M(0, 2)
+        DCM(1, 2) + DCM(2, 1),
+        DCM(2, 0) - DCM(0, 2)
       };
       break;
     // Max was M(2, 2)
     case 2:
       q = {
-        M(2, 0) + M(0, 2),
-        M(2, 1) + M(1, 2),
+        DCM(2, 0) + DCM(0, 2),
+        DCM(2, 1) + DCM(1, 2),
         static_cast<T>(2.0) * max - trace + static_cast<T>(1.0),
-        M(0, 1) - M(1, 0)
+        DCM(0, 1) - DCM(1, 0)
       };
       break;
     // Max was trace(M)
     default:
       q = {
-        M(1, 2) - M(2, 1),
-        M(2, 0) - M(0, 2),
-        M(0, 1) - M(1, 0),
+        DCM(1, 2) - DCM(2, 1),
+        DCM(2, 0) - DCM(0, 2),
+        DCM(0, 1) - DCM(1, 0),
         trace + static_cast<T>(1.0)
       };
   }
@@ -111,7 +138,7 @@ inline void dcm_to_quat(lin::Matrix<T, 3, 3> const &M, lin::Vector<T, 4> &q) {
 }
 
 template <typename T>
-inline void triad(lin::Vector<T, 3> const &R1, lin::Vector<T, 3> const &R2,
+constexpr void triad(lin::Vector<T, 3> const &R1, lin::Vector<T, 3> const &R2,
     lin::Vector<T, 3> const &r1, lin::Vector<T, 3> const &r2,
     lin::Vector<T, 4> &q) {
   // Ensure we are working with normal vectors
@@ -146,7 +173,7 @@ inline void triad(lin::Vector<T, 3> const &R1, lin::Vector<T, 3> const &R2,
 
 // TODO : More strict tolerancing to determine 'antiparallel'
 template <typename T>
-inline void vec_rot_to_quat(lin::Vector<T, 3> const &u,
+constexpr void vec_rot_to_quat(lin::Vector<T, 3> const &u,
     lin::Vector<T, 3> const &v, lin::Vector<T, 4> &q) {
   // Ensure we are working with normal vectors
   GNC_ASSERT_NORMALIZED(u);

--- a/include/gnc/utilities.hpp
+++ b/include/gnc/utilities.hpp
@@ -77,8 +77,8 @@ constexpr void rotate_frame(lin::Vector<T, 4> const &q, lin::Vector<T, 3> &v);
  *  frame. The y vector's projection along x is removed resulting in the second
  *  basis vector for the new frame. The third is generated assuming a right hand
  *  coordinate system.
- *  There is no explicit handling of NaNs built into this functions; however, a
- *  finite input will always yield a finite result. */
+ *  If the vector x and y are very near to being parallel/anti-parallel, DCM is
+ *  set to NaNs. */
 template <typename T>
 constexpr void dcm(lin::Matrix<T, 3, 3> &DCM, lin::Vector<T, 3> const &x,
     lin::Vector<T, 3> const &y);

--- a/include/gnc/utilities.hpp
+++ b/include/gnc/utilities.hpp
@@ -68,7 +68,7 @@ template <typename T>
 constexpr void rotate_frame(lin::Vector<T, 4> const &q, lin::Vector<T, 3> &v);
 
 /** @fn dcm
- *  @param[out] DCM Direction cosine matrix.
+ *  @param[out] DCM Direction cosine matrix.oth x and y must not be the zero vector.
  *  @param[in]  x
  *  @param[in]  y
  *  Generates a DCM from two reference vector in a particular frame. The DCM
@@ -77,8 +77,9 @@ constexpr void rotate_frame(lin::Vector<T, 4> const &q, lin::Vector<T, 3> &v);
  *  frame. The y vector's projection along x is removed resulting in the second
  *  basis vector for the new frame. The third is generated assuming a right hand
  *  coordinate system.
- *  If the vector x and y are very near to being parallel/anti-parallel, DCM is
- *  set to NaNs. */
+ *  Both x and y must not be the zero vector.
+ *  If the vector x and y are very near to being parallel/anti-parallel (
+ *  abs(dot(x_hat, y_hat)) > 0.999), DCM is set to NaNs. */
 template <typename T>
 constexpr void dcm(lin::Matrix<T, 3, 3> &DCM, lin::Vector<T, 3> const &x,
     lin::Vector<T, 3> const &y);

--- a/include/gnc/utilities.hpp
+++ b/include/gnc/utilities.hpp
@@ -67,15 +67,32 @@ constexpr void rotate_frame(lin::Vector<T, 4> const &q,
 template <typename T>
 constexpr void rotate_frame(lin::Vector<T, 4> const &q, lin::Vector<T, 3> &v);
 
+/** @fn dcm
+ *  @param[out] DCM Direction cosine matrix.
+ *  @param[in]  x
+ *  @param[in]  y
+ *  Generates a DCM from two reference vector in a particular frame. The DCM
+ *  will convert from the frame x and y are specified in to the new frame.
+ *  The x input vector is normalized to give the first basis vector of the new
+ *  frame. The y vector's projection along x is removed resulting in the second
+ *  basis vector for the new frame. The third is generated assuming a right hand
+ *  coordinate system.
+ *  There is no explicit handling of NaNs built into this functions; however, a
+ *  finite input will always yield a finite result. */
+template <typename T>
+constexpr void dcm(lin::Matrix<T, 3, 3> &DCM, lin::Vector<T, 3> const &x,
+    lin::Vector<T, 3> const &y);
+
 /** @fn dcm_to_quat
- *  @param[in]  M Direction cosine matrix.
- *  @param[out] q Output quaternion.
+ *  @param[in]  DCM Direction cosine matrix.
+ *  @param[out] q   Output quaternion.
  *  Determines the quaternion corresponding to the provided direction cosine
  *  matrix. The input direction cosine matrix needs to be orthonormal. There is
  *  no explicit handling of NaNs built into this function; however, a finite
  *  input will always yield a finite result. */ 
 template <typename T>
-inline void dcm_to_quat(lin::Matrix<T, 3, 3> const &M, lin::Vector<T, 4> &q);
+constexpr void dcm_to_quat(lin::Matrix<T, 3, 3> const &DCM,
+    lin::Vector<T, 4> &q);
 
 /** @fn triad
  *  @param[in]  R1 First reference vector in a known frame.
@@ -96,7 +113,7 @@ inline void dcm_to_quat(lin::Matrix<T, 3, 3> const &M, lin::Vector<T, 4> &q);
  *  NaNs. Otherwise, a finite input will always yield a finite result.
  *  REQUIRES: R1, R2, r1, and r2 to be unit vectors. */
 template <typename T>
-inline void triad(lin::Vector<T, 3> const &R1, lin::Vector<T, 3> const &R2,
+constexpr void triad(lin::Vector<T, 3> const &R1, lin::Vector<T, 3> const &R2,
     lin::Vector<T, 3> const &r1, lin::Vector<T, 3> const &r2,
     lin::Vector<T, 4> &q);
 
@@ -111,7 +128,7 @@ inline void triad(lin::Vector<T, 3> const &R1, lin::Vector<T, 3> const &R2,
  *  finite result.
  *  REQUIRES: Vectors u and v must both be unit vectors. */
 template <typename T>
-inline void vec_rot_to_quat(lin::Vector<T, 3> const &u,
+constexpr void vec_rot_to_quat(lin::Vector<T, 3> const &u,
     lin::Vector<T, 3> const &v, lin::Vector<T, 4> &q);
 
 }  // namespace utl

--- a/test/test_all/utilities_test.cpp
+++ b/test/test_all/utilities_test.cpp
@@ -5,7 +5,10 @@
 #include "utilities_test.hpp"
 
 #include <gnc/utilities.hpp>
-#include <lin.hpp>
+
+#include <lin/core.hpp>
+#include <lin/generators/randoms.hpp>
+#include <lin/math.hpp>
 
 void test_utilities_quatconj() {
   lin::Vector4f q = {2.0f, 1.0f, -2.5f, 1.0f};
@@ -35,6 +38,19 @@ void test_utilities_rotate_frame() {
   // Expected answer was calculated in MATLAB
   lin::Vector3f ans = { 54.73333f, -0.66667f, -6.46667f};
   TEST_ASSERT_FLOAT_VEC_NEAR(1e-4f, v, ans);
+}
+
+void test_dcm() {
+  lin::Vector3f x {1.0f, 1.0f, 0.0f};
+  lin::Vector3f y {1.0f, 0.0f, 1.0f};
+  lin::Matrix3x3f DCM;
+  gnc::utl::dcm(DCM, x, y);
+  lin::Matrix3x3f ans {
+    0.7071f,  0.7071f,  0.0f,
+    0.4082f, -0.4082f,  0.8165f,
+    0.5774f, -0.5774f, -0.5774f
+  }; // Calculated in MATLAB
+  TEST_ASSERT_FLOAT_WITHIN(1e-3f, 0.0f, lin::fro(DCM - ans));
 }
 
 void test_utilities_dcm_to_quat_case0() {
@@ -143,6 +159,7 @@ void utilities_test() {
   RUN_TEST(test_utilities_quatconj);
   RUN_TEST(test_utilities_quat_cross_mult);
   RUN_TEST(test_utilities_rotate_frame);
+  RUN_TEST(test_dcm);
   RUN_TEST(test_utilities_dcm_to_quat_case0);
   RUN_TEST(test_utilities_dcm_to_quat_case1);
   RUN_TEST(test_utilities_dcm_to_quat_case2);

--- a/test/test_all/utilities_test.cpp
+++ b/test/test_all/utilities_test.cpp
@@ -135,6 +135,19 @@ void test_utilities_triad() {
   // Perform triad
   gnc::utl::triad(n1, n2, b1, b2, q);
   TEST_ASSERT_FLOAT_VEC_NEAR(1e-4f, q, ans);
+  // Parallel inputs should result in NaNs
+  gnc::utl::triad(n1, n1, b1, b2, q);
+  TEST_ASSERT(lin::all(lin::isnan(q)));
+  q = lin::zeros<decltype(q)>();
+  gnc::utl::triad(n1, n2, b1, b1, q);
+  TEST_ASSERT(lin::all(lin::isnan(q)));
+  q = lin::zeros<decltype(q)>();
+  // Anti-parellel inputs should result in NaNs
+  gnc::utl::triad(n1, (-n1).eval(), b1, b2, q);
+  TEST_ASSERT(lin::all(lin::isnan(q)));
+  q = lin::zeros<decltype(q)>();
+  gnc::utl::triad(n1, n2, b1, (-b1).eval(), q);
+  TEST_ASSERT(lin::all(lin::isnan(q)));
 }
 
 void test_utilities_vec_rot_to_quat() {

--- a/test/test_all/utilities_test.cpp
+++ b/test/test_all/utilities_test.cpp
@@ -9,6 +9,7 @@
 #include <lin/core.hpp>
 #include <lin/generators/randoms.hpp>
 #include <lin/math.hpp>
+#include <lin/queries.hpp>
 
 void test_utilities_quatconj() {
   lin::Vector4f q = {2.0f, 1.0f, -2.5f, 1.0f};
@@ -51,6 +52,13 @@ void test_dcm() {
     0.5774f, -0.5774f, -0.5774f
   }; // Calculated in MATLAB
   TEST_ASSERT_FLOAT_WITHIN(1e-3f, 0.0f, lin::fro(DCM - ans));
+  // Parallel inputs should give NaNs
+  gnc::utl::dcm(DCM, x, x);
+  TEST_ASSERT(lin::all(lin::isnan(DCM)));
+  // Anti-parallel inputs should give NaNs as well
+  DCM = lin::zeros<decltype(DCM)>();
+  gnc::utl::dcm(DCM, x, (-x).eval());
+  TEST_ASSERT(lin::all(lin::isnan(DCM)));
 }
 
 void test_utilities_dcm_to_quat_case0() {


### PR DESCRIPTION
# Vector Based DCM Generation Function

Closes #163.

### Summary of changes
- Added a function to generate a right handed DCM given two vectors as a starting basis.
- Cholesky factorization and forward substitution are now in lin as well.
- Fixed a precondition check in the triad function.
- Added a triad NaNs output testcase.

### Ptest Effects
NA

### Testing
See added unit test based on a DCM calculated in MATLAB and the new NaN output testcases.

### Constants
NA

### Documentation Evidence
See inline documentation.
