### PR TITLE
Ground Propagator

### DIFF
--- a/include/orb/GroundPropagator.h
+++ b/include/orb/GroundPropagator.h
@@ -131,9 +131,9 @@ class GroundPropagator {
      */
     void one_grav_call(){
         if(current.numgravcallsleft()){
-            current.one_grav_call();
+            current.onegravcall();
         } else { 
-            catching_up.one_grav_call();
+            catching_up.onegravcall();
         }
         //sort stuff
         if (catching_up.valid() && catching_up.numgravcallsleft()<=current.numgravcallsleft()){

--- a/include/orb/GroundPropagator.h
+++ b/include/orb/GroundPropagator.h
@@ -127,13 +127,13 @@ class GroundPropagator {
     /** Do one grav call to move the propagator towards the current time if needed.
      * The Orbit closest to finish propagating is propagated first.
      * 
-     * grav calls: 1 or 0 if totalnumgravcallsleft() == 0 
+     * grav calls: 1 or 0 if total_num_grav_calls_left() == 0 
      */
-    void onegravcall(){
+    void one_grav_call(){
         if(current.numgravcallsleft()){
-            current.onegravcall();
+            current.one_grav_call();
         } else { 
-            catching_up.onegravcall();
+            catching_up.one_grav_call();
         }
         //sort stuff
         if (catching_up.valid() && catching_up.numgravcallsleft()<=current.numgravcallsleft()){
@@ -147,7 +147,7 @@ class GroundPropagator {
      *
      * grav calls: 0
      */
-    int totalnumgravcallsleft(){
+    int total_num_grav_calls_left() const{
         return current.numgravcallsleft()+catching_up.numgravcallsleft()+to_catch_up.numgravcallsleft();
     }
 
@@ -155,7 +155,7 @@ class GroundPropagator {
      * 
      * grav calls: 0
      */
-    Orbit bestestimate() const{
+    Orbit best_estimate() const{
         return current;
     }
 
@@ -163,7 +163,7 @@ class GroundPropagator {
      * 
      * grav calls: 0
      */
-    void resetorbits(){
+    void reset_orbits(){
         Orbit invalid;
         current=invalid;
         catching_up=invalid;

--- a/include/orb/GroundPropagator.h
+++ b/include/orb/GroundPropagator.h
@@ -38,6 +38,14 @@ namespace orb
 
 /**
  * Class to propagate orbits sent from ground.
+ * 
+ * The GroundPropagator trys to first minimize the number of grav calls needed to get a 
+ * not propagating orbit estimate, and second use the most recently input Orbit.
+ * 
+ * The GroundPropagator assumes the new ground_data is closer to the current time 
+ * than previous ground data, so over writing some ground data if new orbits are sent
+ * faster than they can be processed shouldn't be an issue. 
+ * If that assumion is wrong, then the estimator isn't optimal, but it still works.
  */
 class GroundPropagator {
   private:
@@ -82,6 +90,10 @@ class GroundPropagator {
                 catching_up= ground_data;
             } else{
                 to_catch_up= ground_data;
+                //Assuming the new ground_data is closer to the current time 
+                //than previous ground data, over writing this shouldn't be losing any important 
+                //information. 
+                //If that assumion is wrong, then the estimator isn't optimal, but it still works.
             }
         }
         //start propagators

--- a/include/orb/GroundPropagator.h
+++ b/include/orb/GroundPropagator.h
@@ -1,0 +1,149 @@
+/*
+MIT License
+
+Copyright (c) 2020 Pathfinder for Autonomous Navigation (PAN)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+/**
+ * \file GroundPropagator.h
+ * \author Nathan Zimmerberg
+ * \date 23 APR 2020
+ * \brief A class to propagate orbits sent from ground.
+ */
+
+#pragma once
+
+#include "Orbit.h"
+
+namespace orb
+{
+
+/**
+ * Class to propagate orbits sent from ground.
+ */
+class GroundPropagator {
+  private:
+    /** Current Orbit estimate.*/
+    Orbit current;
+
+    /** Orbit catching up to current time.
+     * If catching_up is valid then current is valid.
+     * If catching_up is valid then current.numgravcallsleft()<catching_up.numgravcallsleft().
+     * If catching_up is valid then catching_up is more recently input than current.
+     */
+    Orbit catching_up;
+
+    /** Orbit to catch up to current time once catching_up is done catching up.
+     * If to_catch_up is valid then catching_up is valid.
+     * If to_catch_up is valid then catching_up.numgravcallsleft()<to_catch_up.numgravcallsleft().
+     * If to_catch_up is valid then to_catch_up is more recently input than catching_up.
+     */
+    Orbit to_catch_up;
+
+  public:
+    /**
+     * Construct GroundPropagator.
+     *
+     * grav calls: 0
+     */
+    GroundPropagator(){}
+
+    /** Input the newest Orbit sent from ground.
+     * 
+     * grav calls: 0
+     * @param[in] ground_data: Orbit sent from ground.
+     * @param[in] gps_time_ns: Time to propagate to (ns).
+     * @param[in] earth_rate_ecef: The earth's angular rate in ecef frame ignored for orbits already propagating(rad/s).
+     */
+    void input(const Orbit& ground_data, const uint64_t& gps_time_ns, const lin::Vector3d& earth_rate_ecef){
+        //add to queue
+        if (ground_data.valid()){
+            if(!current.valid()){
+                current= ground_data;
+            } else if(!catching_up.valid()){
+                catching_up= ground_data;
+            } else{
+                to_catch_up= ground_data;
+            }
+        }
+        //start propagators
+        current.startpropagating(gps_time_ns,earth_rate_ecef);
+        catching_up.startpropagating(gps_time_ns,earth_rate_ecef);
+        to_catch_up.startpropagating(gps_time_ns,earth_rate_ecef);
+        //sort stuff
+        if (to_catch_up.valid() && to_catch_up.numgravcallsleft()<=catching_up.numgravcallsleft()){
+            catching_up= to_catch_up;
+            to_catch_up= Orbit();
+        }
+        if (catching_up.valid() && catching_up.numgravcallsleft()<=current.numgravcallsleft()){
+            current= catching_up;
+            catching_up= to_catch_up;
+            to_catch_up= Orbit();
+        }
+    }
+
+    /** Do one grav call to move the propagator towards the current time if needed.
+     * The Orbit closest to finish propagating is propagated first.
+     * 
+     * grav calls: 1 or 0 if totalnumgravcallsleft() == 0 
+     */
+    void onegravcall(){
+        if(current.numgravcallsleft()){
+            current.onegravcall();
+        } else { 
+            catching_up.onegravcall();
+        }
+        //sort stuff
+        if (catching_up.valid() && catching_up.numgravcallsleft()<=current.numgravcallsleft()){
+            current= catching_up;
+            catching_up= to_catch_up;
+            to_catch_up= Orbit();
+        }
+    }
+
+    /** Return the total number of grav calls need to finish propagating all the orbits.
+     *
+     * grav calls: 0
+     */
+    int totalnumgravcallsleft(){
+        return current.numgravcallsleft()+catching_up.numgravcallsleft()+to_catch_up.numgravcallsleft();
+    }
+
+    /** Returns a reference to the best estimate of the Orbit.
+     * 
+     * grav calls: 0
+     */
+    Orbit bestestimate() const{
+        return current;
+    }
+
+    /** reset all internal orbits to invalid.
+     * 
+     * grav calls: 0
+     */
+    void resetorbits(){
+        Orbit invalid;
+        current=invalid;
+        catching_up=invalid;
+        to_catch_up=invalid;
+    }
+};
+} //namespace orb

--- a/include/orb/GroundPropagator.h
+++ b/include/orb/GroundPropagator.h
@@ -42,10 +42,22 @@ namespace orb
  * The GroundPropagator trys to first minimize the number of grav calls needed to get a 
  * not propagating orbit estimate, and second use the most recently input Orbit.
  * 
- * The GroundPropagator assumes the new ground_data is closer to the current time 
- * than previous ground data, so over writing some ground data if new orbits are sent
- * faster than they can be processed shouldn't be an issue. 
- * If that assumion is wrong, then the estimator isn't optimal, but it still works.
+ * Implimentation details:
+ * 
+ * Under normal conditions, this estimator just propagates the most recently uplinked Orbit.
+ * in current.
+ * 
+ * If a new Orbit get uplinked it will normally get put in catching_up, and the 
+ * estimator will propagate it to the current time in the background 
+ * while still propagating current as the best estimate. 
+ * Once catching_up is done propagating it replaces current.
+ * 
+ * If another Orbit gets uplinked while catching_up is still being propagated 
+ * in the background, it gets stored in to_catch_up. This ensures too many Orbits getting 
+ * uplinked won't overload the estimator and prevent it from making progress.
+ * If to_catch_up takes fewer grav calls to finish propagating than catching_up 
+ * it replaces catching_up.
+ * Also to_catch_up replaces catching_up if catching_up finishes propagating.
  */
 class GroundPropagator {
   private:

--- a/include/orb/GroundPropagator.h
+++ b/include/orb/GroundPropagator.h
@@ -149,7 +149,7 @@ class GroundPropagator {
         return current.numgravcallsleft()+catching_up.numgravcallsleft()+to_catch_up.numgravcallsleft();
     }
 
-    /** Returns a reference to the best estimate of the Orbit.
+    /** Return the best estimate of the Orbit.
      * 
      * grav calls: 0
      */
@@ -157,7 +157,7 @@ class GroundPropagator {
         return current;
     }
 
-    /** reset all internal orbits to invalid.
+    /** Reset all internal orbits to invalid.
      * 
      * grav calls: 0
      */

--- a/include/orb/Orbit.h
+++ b/include/orb/Orbit.h
@@ -409,7 +409,6 @@ class Orbit {
     /** The maximum size of a 1 grav call step (ns). */
     GNC_TRACKED_CONSTANT(static const int64_t,maxshorttimestep,200'000'000LL);
 
-
     /**
      * Put the Orbit in propagating mode or change the end time of a propagating Orbit.
      * Future calls to finishpropagating() or onegravcall() numgravcallsleft() times will finish the propagating.
@@ -451,7 +450,7 @@ class Orbit {
 
     /**
      * Return the number of grav calls needed to finish propagating.
-     * If not propagating Return 0.
+     * If not propagating or invalid Return 0.
      *
      * grav calls: 0
      */
@@ -661,4 +660,4 @@ class Orbit {
         }
     }
 };
-}
+} //namespace orb

--- a/test/test_groundpropagator/test_groundpropagator.cpp
+++ b/test/test_groundpropagator/test_groundpropagator.cpp
@@ -522,6 +522,10 @@ void test_four_inputs_c() {
     est.input(x1,gracestart.nsgpstime(),earth_rate_ecef);
     est.input(x2,gracestart.nsgpstime(),earth_rate_ecef);
     est.input(x3,gracestart.nsgpstime(),earth_rate_ecef);
+    CHECKINVARIANT(est);
+    TEST_ASSERT(est.current.valid());
+    TEST_ASSERT(!est.catching_up.valid());
+    TEST_ASSERT(!est.to_catch_up.valid());
     x3.startpropagating(gracestart.nsgpstime(),earth_rate_ecef);
     orb::Orbit best= est.best_estimate();
     TEST_ASSERT_EQUAL_MEMORY (&best, &x3, sizeof(orb::Orbit));   
@@ -529,7 +533,7 @@ void test_four_inputs_c() {
 
 /** Test inputting 4 valid Orbits.
  * The 4th input should replace the 1st because it is most up to date.*/
-void test_four_inputs_c() {
+void test_four_inputs_d() {
     orb::GroundPropagator est;
     orb::Orbit x0(gracestart.nsgpstime()-1000'000'000'000LL,gracestart.recef(),gracestart.vecef());
     orb::Orbit x1(gracestart.nsgpstime()-2000'000'000'000LL,gracestart.recef(),gracestart.vecef());
@@ -542,9 +546,212 @@ void test_four_inputs_c() {
     est.input(x1,gracestart.nsgpstime(),earth_rate_ecef);
     est.input(x2,gracestart.nsgpstime(),earth_rate_ecef);
     est.input(x3,gracestart.nsgpstime(),earth_rate_ecef);
+    CHECKINVARIANT(est);
+    TEST_ASSERT(est.current.valid());
+    TEST_ASSERT(!est.catching_up.valid());
+    TEST_ASSERT(!est.to_catch_up.valid());
     x3.startpropagating(gracestart.nsgpstime(),earth_rate_ecef);
     orb::Orbit best= est.best_estimate();
     TEST_ASSERT_EQUAL_MEMORY (&best, &x3, sizeof(orb::Orbit));   
+}
+
+/** Test inputting 4 valid Orbits.
+ * The 4th input should replace the 1st because it is equally to date.*/
+void test_four_inputs_e() {
+    orb::GroundPropagator est;
+    orb::Orbit x0(gracestart.nsgpstime()-1000'000'000'000LL,gracestart.recef(),gracestart.vecef());
+    orb::Orbit x1(gracestart.nsgpstime()-2000'000'000'000LL,gracestart.recef(),gracestart.vecef());
+    x1.applydeltav({1.0,0.0,0.0});
+    orb::Orbit x2(gracestart.nsgpstime()-3000'000'000'000LL,gracestart.recef(),gracestart.vecef());
+    x2.applydeltav({2.0,0.0,0.0});
+    orb::Orbit x3(gracestart.nsgpstime()-1000'000'000'000LL,gracestart.recef(),gracestart.vecef());
+    x3.applydeltav({3.0,0.0,0.0});
+    est.input(x0,gracestart.nsgpstime(),earth_rate_ecef);
+    est.input(x1,gracestart.nsgpstime(),earth_rate_ecef);
+    est.input(x2,gracestart.nsgpstime(),earth_rate_ecef);
+    est.input(x3,gracestart.nsgpstime(),earth_rate_ecef);
+    CHECKINVARIANT(est);
+    TEST_ASSERT(est.current.valid());
+    TEST_ASSERT(!est.catching_up.valid());
+    TEST_ASSERT(!est.to_catch_up.valid());
+    x3.startpropagating(gracestart.nsgpstime(),earth_rate_ecef);
+    orb::Orbit best= est.best_estimate();
+    TEST_ASSERT_EQUAL_MEMORY (&best, &x3, sizeof(orb::Orbit));   
+}
+
+/** Test inputting 4 valid Orbits.
+ * The 4th input should replace the 2st because it is more up to date.*/
+void test_four_inputs_f() {
+    orb::GroundPropagator est;
+    orb::Orbit x0(gracestart.nsgpstime()-1000'000'000'000LL,gracestart.recef(),gracestart.vecef());
+    orb::Orbit x1(gracestart.nsgpstime()-2000'000'000'000LL,gracestart.recef(),gracestart.vecef());
+    x1.applydeltav({1.0,0.0,0.0});
+    orb::Orbit x2(gracestart.nsgpstime()-3000'000'000'000LL,gracestart.recef(),gracestart.vecef());
+    x2.applydeltav({2.0,0.0,0.0});
+    orb::Orbit x3(gracestart.nsgpstime()-1500'000'000'000LL,gracestart.recef(),gracestart.vecef());
+    x3.applydeltav({3.0,0.0,0.0});
+    est.input(x0,gracestart.nsgpstime(),earth_rate_ecef);
+    est.input(x1,gracestart.nsgpstime(),earth_rate_ecef);
+    est.input(x2,gracestart.nsgpstime(),earth_rate_ecef);
+    est.input(x3,gracestart.nsgpstime(),earth_rate_ecef);
+    CHECKINVARIANT(est);
+    TEST_ASSERT(est.current.valid());
+    TEST_ASSERT(est.catching_up.valid());
+    TEST_ASSERT(!est.to_catch_up.valid());
+    x0.startpropagating(gracestart.nsgpstime(),earth_rate_ecef);
+    x1.startpropagating(gracestart.nsgpstime(),earth_rate_ecef);
+    x2.startpropagating(gracestart.nsgpstime(),earth_rate_ecef);
+    x3.startpropagating(gracestart.nsgpstime(),earth_rate_ecef);
+    TEST_ASSERT_EQUAL_MEMORY (&est.current, &x0, sizeof(orb::Orbit));
+    TEST_ASSERT_EQUAL_MEMORY (&est.catching_up, &x3, sizeof(orb::Orbit));   
+}
+
+/** Test inputting 4 valid Orbits.
+ * The 4th input should replace the 2st because it is equally up to date.*/
+void test_four_inputs_g() {
+    orb::GroundPropagator est;
+    orb::Orbit x0(gracestart.nsgpstime()-1000'000'000'000LL,gracestart.recef(),gracestart.vecef());
+    orb::Orbit x1(gracestart.nsgpstime()-2000'000'000'000LL,gracestart.recef(),gracestart.vecef());
+    x1.applydeltav({1.0,0.0,0.0});
+    orb::Orbit x2(gracestart.nsgpstime()-3000'000'000'000LL,gracestart.recef(),gracestart.vecef());
+    x2.applydeltav({2.0,0.0,0.0});
+    orb::Orbit x3(gracestart.nsgpstime()-2000'000'000'000LL,gracestart.recef(),gracestart.vecef());
+    x3.applydeltav({3.0,0.0,0.0});
+    est.input(x0,gracestart.nsgpstime(),earth_rate_ecef);
+    est.input(x1,gracestart.nsgpstime(),earth_rate_ecef);
+    est.input(x2,gracestart.nsgpstime(),earth_rate_ecef);
+    est.input(x3,gracestart.nsgpstime(),earth_rate_ecef);
+    CHECKINVARIANT(est);
+    TEST_ASSERT(est.current.valid());
+    TEST_ASSERT(est.catching_up.valid());
+    TEST_ASSERT(!est.to_catch_up.valid());
+    x0.startpropagating(gracestart.nsgpstime(),earth_rate_ecef);
+    x1.startpropagating(gracestart.nsgpstime(),earth_rate_ecef);
+    x2.startpropagating(gracestart.nsgpstime(),earth_rate_ecef);
+    x3.startpropagating(gracestart.nsgpstime(),earth_rate_ecef);
+    TEST_ASSERT_EQUAL_MEMORY (&est.current, &x0, sizeof(orb::Orbit));
+    TEST_ASSERT_EQUAL_MEMORY (&est.catching_up, &x3, sizeof(orb::Orbit));   
+}
+
+/** Test inputting 4 valid Orbits.
+ * The 3rd input should replace the 1st 
+ * because it is more up to date when the current time changes,
+ * but the 4th input should be moved to catching_up because it 2nd closest.*/
+void test_four_inputs_h() {
+    orb::GroundPropagator est;
+    orb::Orbit x0(gracestart.nsgpstime()-1000'000'000'000LL,gracestart.recef(),gracestart.vecef());
+    orb::Orbit x1(gracestart.nsgpstime()-2000'000'000'000LL,gracestart.recef(),gracestart.vecef());
+    x1.applydeltav({1.0,0.0,0.0});
+    orb::Orbit x2(gracestart.nsgpstime()-3000'000'000'000LL,gracestart.recef(),gracestart.vecef());
+    x2.applydeltav({2.0,0.0,0.0});
+    orb::Orbit x3(gracestart.nsgpstime()-4000'000'000'000LL,gracestart.recef(),gracestart.vecef());
+    x3.applydeltav({3.0,0.0,0.0});
+    est.input(x0,gracestart.nsgpstime(),earth_rate_ecef);
+    est.input(x1,gracestart.nsgpstime(),earth_rate_ecef);
+    est.input(x2,gracestart.nsgpstime(),earth_rate_ecef);
+    uint64_t t= gracestart.nsgpstime()-3200'000'000'000LL;
+    est.input(x3,t,earth_rate_ecef);
+    CHECKINVARIANT(est);
+    TEST_ASSERT(est.current.valid());
+    TEST_ASSERT(est.catching_up.valid());
+    TEST_ASSERT(!est.to_catch_up.valid());
+    x0.startpropagating(t,earth_rate_ecef);
+    x1.startpropagating(t,earth_rate_ecef);
+    x2.startpropagating(t,earth_rate_ecef);
+    x3.startpropagating(t,earth_rate_ecef);
+    TEST_ASSERT_EQUAL_MEMORY (&est.current, &x2, sizeof(orb::Orbit));
+    TEST_ASSERT_EQUAL_MEMORY (&est.catching_up, &x3, sizeof(orb::Orbit));   
+}
+
+/** Test inputting 4 valid Orbits.
+ * The 2rd input should replace the 1st 
+ * because it is more up to date when the current time changes,
+ * but the 4th input should be moved to to_catch_up.*/
+void test_four_inputs_i() {
+    orb::GroundPropagator est;
+    orb::Orbit x0(gracestart.nsgpstime()-1000'000'000'000LL,gracestart.recef(),gracestart.vecef());
+    orb::Orbit x1(gracestart.nsgpstime()-2000'000'000'000LL,gracestart.recef(),gracestart.vecef());
+    x1.applydeltav({1.0,0.0,0.0});
+    orb::Orbit x2(gracestart.nsgpstime()-3000'000'000'000LL,gracestart.recef(),gracestart.vecef());
+    x2.applydeltav({2.0,0.0,0.0});
+    orb::Orbit x3(gracestart.nsgpstime()-4000'000'000'000LL,gracestart.recef(),gracestart.vecef());
+    x3.applydeltav({3.0,0.0,0.0});
+    est.input(x0,gracestart.nsgpstime(),earth_rate_ecef);
+    est.input(x1,gracestart.nsgpstime(),earth_rate_ecef);
+    est.input(x2,gracestart.nsgpstime(),earth_rate_ecef);
+    uint64_t t= gracestart.nsgpstime()-2200'000'000'000LL;
+    est.input(x3,t,earth_rate_ecef);
+    CHECKINVARIANT(est);
+    TEST_ASSERT(est.current.valid());
+    TEST_ASSERT(est.catching_up.valid());
+    TEST_ASSERT(est.to_catch_up.valid());
+    x0.startpropagating(t,earth_rate_ecef);
+    x1.startpropagating(t,earth_rate_ecef);
+    x2.startpropagating(t,earth_rate_ecef);
+    x3.startpropagating(t,earth_rate_ecef);
+    TEST_ASSERT_EQUAL_MEMORY (&est.current, &x1, sizeof(orb::Orbit));
+    TEST_ASSERT_EQUAL_MEMORY (&est.catching_up, &x2, sizeof(orb::Orbit));
+    TEST_ASSERT_EQUAL_MEMORY (&est.to_catch_up, &x3, sizeof(orb::Orbit));
+}
+
+/** Test propagating only one orbit.*/
+void test_one_orbit_prop() {
+    orb::GroundPropagator est;
+    orb::Orbit x0= gracestart;
+    uint64_t t0= gracestart.nsgpstime();
+    est.input(x0,t0,earth_rate_ecef);
+    auto est_copy= est;
+    TEST_ASSERT_FALSE(est.total_num_grav_calls_left());
+    est.one_grav_call();
+    //there should be no effect because everything is caught up
+    TEST_ASSERT_EQUAL_MEMORY(&est, &est_copy, sizeof(orb::GroundPropagator));
+    //propagate
+    est.input(orb::Orbit(),t0+100'000'000'000LL,earth_rate_ecef);
+    TEST_ASSERT(est.current.valid());
+    TEST_ASSERT(!est.catching_up.valid());
+    TEST_ASSERT(!est.to_catch_up.valid());
+    x0.startpropagating(t0+100'000'000'000LL,earth_rate_ecef);
+    TEST_ASSERT_EQUAL_MEMORY (&est.current, &x0, sizeof(orb::Orbit));
+    while(x0.numgravcallsleft()){
+        est.one_grav_call();
+        x0.onegravcall();
+    }
+    TEST_ASSERT(est.current.valid());
+    TEST_ASSERT(!est.catching_up.valid());
+    TEST_ASSERT(!est.to_catch_up.valid());
+    TEST_ASSERT_EQUAL_MEMORY (&est.current, &x0, sizeof(orb::Orbit));
+}
+
+/** Test that propagator can't be overloaded.*/
+void test_overloading() {
+    orb::GroundPropagator est;
+    uint64_t t0= gracestart.nsgpstime();
+    lin::Vector3d v0= gracestart.vecef();
+    lin::Vector3d r0= gracestart.recef();
+    orb::Orbit x0(t0,r0,v0);
+    orb::Orbit x1(t0-1000'000'000'000LL,r0,v0);
+    x1.applydeltav({1.0,0.0,0.0});
+    orb::Orbit x2(t0-2000'000'000'000LL,r0,v0);
+    x2.applydeltav({2.0,0.0,0.0});
+    est.input(x0,t0,earth_rate_ecef);
+    est.input(x1,t0,earth_rate_ecef);
+    est.input(x2,t0,earth_rate_ecef);
+    x1.startpropagating(t0,earth_rate_ecef);
+    int64_t dt= 120'000'000LL;
+    int i=0;
+    while(x1.numgravcallsleft()){
+        i++;
+        //every cycle add on Orbit data 1500s old
+        orb::Orbit x3(t0-1500'000'000'000LL+i*dt,r0,v0);
+        x3.applydeltav({3.0,0.0,0.0});
+        est.input(x3,t0+i*dt,earth_rate_ecef);
+        x1.startpropagating(t0+i*dt,earth_rate_ecef);
+        est.one_grav_call();//this props current
+        x1.onegravcall();
+        est.one_grav_call();//this should prop catching_up
+    }
+    //x1 should be caugth up now
+    TEST_ASSERT_EQUAL_MEMORY (&est.current, &x1, sizeof(orb::Orbit));
 }
 
 
@@ -718,63 +925,6 @@ void test_lots_of_ground_data_catchingup() {
     PAN_TEST_ASSERT_LIN_3VECT_WITHIN(1E-3, best.recef(), lastsentorbit.recef());
 }
 
-void test_edge_cases() {
-    orb::GroundPropagator est;
-    uint64_t t0= gracestart.nsgpstime();
-    lin::Vector3d r0= gracestart.recef();
-    lin::Vector3d v0= gracestart.vecef();
-    est.input(orb::Orbit(t0+100,r0,v0),t0,earth_rate_ecef);
-    orb::Orbit best= est.best_estimate();
-    TEST_ASSERT_TRUE(best.valid());
-    TEST_ASSERT_EQUAL_INT(best.numgravcallsleft(),1);
-
-    est.input(orb::Orbit(t0,r0,v0),t0,earth_rate_ecef);
-    best= est.best_estimate();
-    TEST_ASSERT_TRUE(best.valid());
-    TEST_ASSERT_FALSE(best.numgravcallsleft());
-    TEST_ASSERT_FALSE(est.total_num_grav_calls_left());
-    TEST_ASSERT_TRUE(best.nsgpstime()==t0);
-
-    est.input(orb::Orbit(t0,r0,v0),t0,earth_rate_ecef);
-    best= est.best_estimate();
-    TEST_ASSERT_TRUE(best.valid());
-    TEST_ASSERT_FALSE(best.numgravcallsleft());
-    TEST_ASSERT_FALSE(est.total_num_grav_calls_left());
-    TEST_ASSERT_TRUE(best.nsgpstime()==t0);
-
-    est.input(orb::Orbit(t0-100,r0,v0),t0,earth_rate_ecef);
-    best= est.best_estimate();
-    TEST_ASSERT_TRUE(best.valid());
-    TEST_ASSERT_FALSE(best.numgravcallsleft());
-    TEST_ASSERT_EQUAL_INT(est.total_num_grav_calls_left(),1);
-    TEST_ASSERT_TRUE(best.nsgpstime()==t0);
-
-    est.input(orb::Orbit(t0-1'000'000'000LL,r0,v0),t0,earth_rate_ecef);
-    best= est.best_estimate();
-    TEST_ASSERT_TRUE(best.valid());
-    TEST_ASSERT_FALSE(best.numgravcallsleft());
-    TEST_ASSERT_TRUE(est.total_num_grav_calls_left()>1);
-    TEST_ASSERT_TRUE(best.nsgpstime()==t0);
-
-    est.input(orb::Orbit(t0+100LL,r0,v0),t0-1'000'000'000LL,earth_rate_ecef);
-    best= est.best_estimate();
-    TEST_ASSERT_TRUE(best.valid());
-    TEST_ASSERT_FALSE(best.numgravcallsleft());
-    TEST_ASSERT_TRUE(est.total_num_grav_calls_left());
-
-    est.input(orb::Orbit(),t0+100LL,earth_rate_ecef);
-    best= est.best_estimate();
-    TEST_ASSERT_TRUE(best.valid());
-    TEST_ASSERT_FALSE(best.numgravcallsleft());
-    TEST_ASSERT_TRUE(est.total_num_grav_calls_left()==0);
-    TEST_ASSERT_TRUE(best.nsgpstime()==t0+100);
-
-    est.reset_orbits();
-    best= est.best_estimate();
-    TEST_ASSERT_FALSE(best.valid());
-
-}
-
 int test_orbit() {
     UNITY_BEGIN();
     RUN_TEST(test_basic_constructors);
@@ -791,15 +941,21 @@ int test_orbit() {
     RUN_TEST(test_three_inputs_b);
     RUN_TEST(test_three_inputs_c);
     RUN_TEST(test_three_inputs_d);
-    RUN_TEST(test_three_inputs_d);
     RUN_TEST(test_four_inputs_a);
     RUN_TEST(test_four_inputs_b);
     RUN_TEST(test_four_inputs_c);
+    RUN_TEST(test_four_inputs_d);
+    RUN_TEST(test_four_inputs_e);
+    RUN_TEST(test_four_inputs_f);
+    RUN_TEST(test_four_inputs_g);
+    RUN_TEST(test_four_inputs_h);
+    RUN_TEST(test_four_inputs_i);
+    RUN_TEST(test_one_orbit_prop);
+    RUN_TEST(test_overloading);
     RUN_TEST(test_normal_use);
     RUN_TEST(test_time_going_backwards);
     RUN_TEST(test_lots_of_ground_data);
     RUN_TEST(test_lots_of_ground_data_catchingup);
-    RUN_TEST(test_edge_cases);
     return UNITY_END();
 }
 

--- a/test/test_groundpropagator/test_groundpropagator.cpp
+++ b/test/test_groundpropagator/test_groundpropagator.cpp
@@ -925,6 +925,20 @@ void test_lots_of_ground_data_catchingup() {
     PAN_TEST_ASSERT_LIN_3VECT_WITHIN(1E-3, best.recef(), lastsentorbit.recef());
 }
 
+void test_reset_orbits() {
+    orb::GroundPropagator est;
+    est.reset_orbits();
+    TEST_ASSERT(!est.current.valid());
+    TEST_ASSERT(!est.catching_up.valid());
+    TEST_ASSERT(!est.to_catch_up.valid());
+    est.input(gracestart,gracestart.nsgpstime(),earth_rate_ecef);
+    est.reset_orbits();
+    // reseting should revert to init
+    TEST_ASSERT(!est.current.valid());
+    TEST_ASSERT(!est.catching_up.valid());
+    TEST_ASSERT(!est.to_catch_up.valid());
+}
+
 int test_orbit() {
     UNITY_BEGIN();
     RUN_TEST(test_basic_constructors);
@@ -956,6 +970,7 @@ int test_orbit() {
     RUN_TEST(test_time_going_backwards);
     RUN_TEST(test_lots_of_ground_data);
     RUN_TEST(test_lots_of_ground_data_catchingup);
+    RUN_TEST(test_reset_orbits);
     return UNITY_END();
 }
 

--- a/test/test_groundpropagator/test_groundpropagator.cpp
+++ b/test/test_groundpropagator/test_groundpropagator.cpp
@@ -33,9 +33,9 @@ lin::Vector3d earth_rate_ecef= {0.000000707063506E-4,-0.000001060595259E-4,0.729
 
 void test_basic_constructors() {
     orb::GroundPropagator est;
-    orb::Orbit x= est.bestestimate();
+    orb::Orbit x= est.best_estimate();
     TEST_ASSERT_FALSE(x.valid());
-    TEST_ASSERT_EQUAL_INT(est.totalnumgravcallsleft(),0);
+    TEST_ASSERT_EQUAL_INT(est.total_num_grav_calls_left(),0);
 }
 
 
@@ -88,18 +88,18 @@ void test_normal_use() {
     uint64_t dtgpsns= 120'000'000ULL;
     //start est with an up to date current estimate.
     est.input(orb::Orbit(gpsns,gracestart.recef(),gracestart.vecef()),gpsns,earth_rate_ecef);
-    orb::Orbit best= est.bestestimate();
+    orb::Orbit best= est.best_estimate();
     TEST_ASSERT_TRUE(best.valid());
     TEST_ASSERT_FALSE(best.numgravcallsleft());
     for (int controlcycle=0; controlcycle<1000; controlcycle++){
         gpsns+=dtgpsns;
         orb::Orbit ground_data= real_fake_ground_data(controlcycle);
         est.input(ground_data,gpsns,earth_rate_ecef);
-        est.onegravcall();
-        est.onegravcall();
-        est.onegravcall();
-        est.onegravcall();
-        orb::Orbit best= est.bestestimate();
+        est.one_grav_call();
+        est.one_grav_call();
+        est.one_grav_call();
+        est.one_grav_call();
+        orb::Orbit best= est.best_estimate();
         //assert that the orbit never gets invalid or propagating
         TEST_ASSERT_TRUE(best.valid());
         TEST_ASSERT_FALSE(best.numgravcallsleft());
@@ -107,7 +107,7 @@ void test_normal_use() {
     orb::Orbit lastsentorbit= grace100s;
     lastsentorbit.startpropagating(gpsns,earth_rate_ecef);
     lastsentorbit.finishpropagating();
-    best= est.bestestimate();
+    best= est.best_estimate();
     TEST_ASSERT_TRUE(best.valid());
     TEST_ASSERT_FALSE(best.numgravcallsleft());
     TEST_ASSERT_TRUE(best.nsgpstime()==lastsentorbit.nsgpstime());
@@ -123,18 +123,18 @@ void test_time_going_backwards() {
     int64_t dtgpsns= -120'000'000LL;
     //start est with an up to date current estimate.
     est.input(orb::Orbit(gpsns,gracestart.recef(),gracestart.vecef()),gpsns,earth_rate_ecef);
-    orb::Orbit best= est.bestestimate();
+    orb::Orbit best= est.best_estimate();
     TEST_ASSERT_TRUE(best.valid());
     TEST_ASSERT_FALSE(best.numgravcallsleft());
     for (int controlcycle=0; controlcycle<1000; controlcycle++){
         gpsns+=dtgpsns;
         orb::Orbit ground_data= real_fake_ground_data(controlcycle);
         est.input(ground_data,gpsns,earth_rate_ecef);
-        est.onegravcall();
-        est.onegravcall();
-        est.onegravcall();
-        est.onegravcall();
-        orb::Orbit best= est.bestestimate();
+        est.one_grav_call();
+        est.one_grav_call();
+        est.one_grav_call();
+        est.one_grav_call();
+        orb::Orbit best= est.best_estimate();
         //assert that the orbit never gets invalid or propagating
         TEST_ASSERT_TRUE(best.valid());
         TEST_ASSERT_FALSE(best.numgravcallsleft());
@@ -142,7 +142,7 @@ void test_time_going_backwards() {
     orb::Orbit lastsentorbit= grace100s;
     lastsentorbit.startpropagating(gpsns,earth_rate_ecef);
     lastsentorbit.finishpropagating();
-    best= est.bestestimate();
+    best= est.best_estimate();
     TEST_ASSERT_TRUE(best.valid());
     TEST_ASSERT_FALSE(best.numgravcallsleft());
     TEST_ASSERT_TRUE(best.nsgpstime()==lastsentorbit.nsgpstime());
@@ -157,20 +157,20 @@ void test_lots_of_ground_data() {
     int64_t dtgpsns= 120'000'000LL;
     //start est with an up to date current estimate.
     est.input(orb::Orbit(gpsns,gracestart.recef(),gracestart.vecef()),gpsns,earth_rate_ecef);
-    orb::Orbit best= est.bestestimate();
+    orb::Orbit best= est.best_estimate();
     TEST_ASSERT_TRUE(best.valid());
     TEST_ASSERT_FALSE(best.numgravcallsleft());
     for (int controlcycle=0; controlcycle<1000; controlcycle++){
         gpsns+=dtgpsns;
         orb::Orbit ground_data= gracestart;//ground data sent every controll cycle
         est.input(ground_data,gpsns,earth_rate_ecef);
-        est.onegravcall();
+        est.one_grav_call();
     }
     //because there is only one grav call per control cycle the propagator can never catch up.
     orb::Orbit lastsentorbit= orb::Orbit(gracestart.nsgpstime()+1000'000'000'000ULL,gracestart.recef(),gracestart.vecef());
     lastsentorbit.startpropagating(gpsns,earth_rate_ecef);
     lastsentorbit.finishpropagating();
-    best= est.bestestimate();
+    best= est.best_estimate();
     TEST_ASSERT_TRUE(best.valid());
     TEST_ASSERT_FALSE(best.numgravcallsleft());
     TEST_ASSERT_TRUE(best.nsgpstime()==lastsentorbit.nsgpstime());
@@ -185,21 +185,21 @@ void test_lots_of_ground_data_catchingup() {
     int64_t dtgpsns= 120'000'000LL;
     //start est with an up to date current estimate.
     est.input(orb::Orbit(gpsns,gracestart.recef(),gracestart.vecef()),gpsns,earth_rate_ecef);
-    orb::Orbit best= est.bestestimate();
+    orb::Orbit best= est.best_estimate();
     TEST_ASSERT_TRUE(best.valid());
     TEST_ASSERT_FALSE(best.numgravcallsleft());
     for (int controlcycle=0; controlcycle<1000; controlcycle++){
         gpsns+=dtgpsns;
         orb::Orbit ground_data= gracestart;//ground data sent every controll cycle
         est.input(ground_data,gpsns,earth_rate_ecef);
-        est.onegravcall();
-        est.onegravcall();
+        est.one_grav_call();
+        est.one_grav_call();
     }
     //because there is two grav calls per control cycle the propagator can catch up.
     orb::Orbit lastsentorbit= gracestart;
     lastsentorbit.startpropagating(gpsns,earth_rate_ecef);
     lastsentorbit.finishpropagating();
-    best= est.bestestimate();
+    best= est.best_estimate();
     TEST_ASSERT_TRUE(best.valid());
     TEST_ASSERT_FALSE(best.numgravcallsleft());
     TEST_ASSERT_TRUE(best.nsgpstime()==lastsentorbit.nsgpstime());
@@ -213,56 +213,56 @@ void test_edge_cases() {
     lin::Vector3d r0= gracestart.recef();
     lin::Vector3d v0= gracestart.vecef();
     est.input(orb::Orbit(t0+100,r0,v0),t0,earth_rate_ecef);
-    orb::Orbit best= est.bestestimate();
+    orb::Orbit best= est.best_estimate();
     TEST_ASSERT_TRUE(best.valid());
     TEST_ASSERT_EQUAL_INT(best.numgravcallsleft(),1);
 
     est.input(orb::Orbit(t0,r0,v0),t0,earth_rate_ecef);
-    best= est.bestestimate();
+    best= est.best_estimate();
     TEST_ASSERT_TRUE(best.valid());
     TEST_ASSERT_FALSE(best.numgravcallsleft());
-    TEST_ASSERT_FALSE(est.totalnumgravcallsleft());
+    TEST_ASSERT_FALSE(est.total_num_grav_calls_left());
     TEST_ASSERT_TRUE(best.nsgpstime()==t0);
 
     est.input(orb::Orbit(t0,r0,v0),t0,earth_rate_ecef);
-    best= est.bestestimate();
+    best= est.best_estimate();
     TEST_ASSERT_TRUE(best.valid());
     TEST_ASSERT_FALSE(best.numgravcallsleft());
-    TEST_ASSERT_FALSE(est.totalnumgravcallsleft());
+    TEST_ASSERT_FALSE(est.total_num_grav_calls_left());
     TEST_ASSERT_TRUE(best.nsgpstime()==t0);
 
     est.input(orb::Orbit(t0-100,r0,v0),t0,earth_rate_ecef);
-    best= est.bestestimate();
+    best= est.best_estimate();
     TEST_ASSERT_TRUE(best.valid());
     TEST_ASSERT_FALSE(best.numgravcallsleft());
-    TEST_ASSERT_EQUAL_INT(est.totalnumgravcallsleft(),1);
+    TEST_ASSERT_EQUAL_INT(est.total_num_grav_calls_left(),1);
     TEST_ASSERT_TRUE(best.nsgpstime()==t0);
 
     est.input(orb::Orbit(t0-1'000'000'000LL,r0,v0),t0,earth_rate_ecef);
-    best= est.bestestimate();
+    best= est.best_estimate();
     TEST_ASSERT_TRUE(best.valid());
     TEST_ASSERT_FALSE(best.numgravcallsleft());
-    TEST_ASSERT_TRUE(est.totalnumgravcallsleft()>1);
+    TEST_ASSERT_TRUE(est.total_num_grav_calls_left()>1);
     TEST_ASSERT_TRUE(best.nsgpstime()==t0);
 
     est.input(orb::Orbit(t0+100LL,r0,v0),t0-1'000'000'000LL,earth_rate_ecef);
-    best= est.bestestimate();
+    best= est.best_estimate();
     TEST_ASSERT_TRUE(best.valid());
     TEST_ASSERT_TRUE(best.numgravcallsleft());
-    TEST_ASSERT_TRUE(est.totalnumgravcallsleft()>1);
+    TEST_ASSERT_TRUE(est.total_num_grav_calls_left()>1);
     best.startpropagating(t0-100,earth_rate_ecef);
     TEST_ASSERT_FALSE(best.numgravcallsleft());
     TEST_ASSERT_TRUE(best.nsgpstime()==t0-100);
 
     est.input(orb::Orbit(),t0+100LL,earth_rate_ecef);
-    best= est.bestestimate();
+    best= est.best_estimate();
     TEST_ASSERT_TRUE(best.valid());
     TEST_ASSERT_FALSE(best.numgravcallsleft());
-    TEST_ASSERT_TRUE(est.totalnumgravcallsleft()==0);
+    TEST_ASSERT_TRUE(est.total_num_grav_calls_left()==0);
     TEST_ASSERT_TRUE(best.nsgpstime()==t0+100);
 
-    est.resetorbits();
-    best= est.bestestimate();
+    est.reset_orbits();
+    best= est.best_estimate();
     TEST_ASSERT_FALSE(best.valid());
 
 }

--- a/test/test_groundpropagator/test_groundpropagator.cpp
+++ b/test/test_groundpropagator/test_groundpropagator.cpp
@@ -11,14 +11,6 @@
 #include <orb/Orbit.h>
 #include <orb/GroundPropagator.h>
 
-//0 or 1 that can't be calculated at compile time.
-#ifdef DESKTOP
-#define notcompiletime (rand()%2)
-#else
-#include <Arduino.h>
-#define notcompiletime (millis()%2)
-#endif
-
 /** Check some of the internal invariants are true.*/
 #define CHECKINVARIANT(est) do {\
             if (est.catching_up.valid()){ \
@@ -931,9 +923,11 @@ void test_reset_orbits() {
     TEST_ASSERT(!est.current.valid());
     TEST_ASSERT(!est.catching_up.valid());
     TEST_ASSERT(!est.to_catch_up.valid());
-    est.input(gracestart,gracestart.nsgpstime(),earth_rate_ecef);
+    est.input(gracestart,gracestart.nsgpstime()+1000'000'000'000LL,earth_rate_ecef);
+    est.input(gracestart,gracestart.nsgpstime()+2000'000'000'000LL,earth_rate_ecef);
+    est.input(gracestart,gracestart.nsgpstime()+3000'000'000'000LL,earth_rate_ecef);
     est.reset_orbits();
-    // reseting should revert to init
+    // reseting should invalidate all orbits
     TEST_ASSERT(!est.current.valid());
     TEST_ASSERT(!est.catching_up.valid());
     TEST_ASSERT(!est.to_catch_up.valid());

--- a/test/test_groundpropagator/test_groundpropagator.cpp
+++ b/test/test_groundpropagator/test_groundpropagator.cpp
@@ -5,6 +5,10 @@
 #include <gnc/constants.hpp>
 #include <gnc/config.hpp>
 
+#ifndef DESKTOP
+#include <Arduino.h>
+#endif
+
 //UTILITY MACROS
 #include <unity.h>
 #include "../custom_assertions.hpp"

--- a/test/test_groundpropagator/test_groundpropagator.cpp
+++ b/test/test_groundpropagator/test_groundpropagator.cpp
@@ -1,0 +1,295 @@
+#include <stdio.h>
+#include <cstdint>
+#include <limits>
+#include <lin.hpp>
+#include <gnc/constants.hpp>
+#include <gnc/config.hpp>
+
+//UTILITY MACROS
+#include <unity.h>
+#include "../custom_assertions.hpp"
+#include <orb/Orbit.h>
+#include <orb/GroundPropagator.h>
+
+//0 or 1 that can't be calculated at compile time.
+#ifdef DESKTOP
+#define notcompiletime (rand()%2)
+#else
+#include <Arduino.h>
+#define notcompiletime (millis()%2)
+#endif
+
+//grace orbit initial
+const orb::Orbit gracestart(uint64_t(gnc::constant::init_gps_week_number)*gnc::constant::NANOSECONDS_IN_WEEK,{-6522019.833240811L, 2067829.846415895L, 776905.9724453629L},{941.0211143841228L, 85.66662333729801L, 7552.870253470936L});
+
+//grace orbit 100 seconds later
+const orb::Orbit grace100s(uint64_t(gnc::constant::init_gps_week_number)*gnc::constant::NANOSECONDS_IN_WEEK+100'000'000'000ULL,{-6388456.55330517L, 2062929.296577276L, 1525892.564091281L},{1726.923087560988L, -185.5049475128178L, 7411.544615026139L});
+
+//grace orbit 13700 seconds later
+const orb::Orbit grace13700s(uint64_t(gnc::constant::init_gps_week_number)*gnc::constant::NANOSECONDS_IN_WEEK+13700'000'000'000ULL,{1579190.147083268L, -6066459.613667888L, 2785708.976728437L},{480.8261476296949L, -3083.977113497177L, -6969.470748202005L});
+
+//earth rate in ecef (rad/s)
+lin::Vector3d earth_rate_ecef= {0.000000707063506E-4,-0.000001060595259E-4,0.729211585530000E-4};
+
+void test_basic_constructors() {
+    orb::GroundPropagator est;
+    orb::Orbit x= est.bestestimate();
+    TEST_ASSERT_FALSE(x.valid());
+    TEST_ASSERT_EQUAL_INT(est.totalnumgravcallsleft(),0);
+}
+
+
+/** Returns real fake orbits sent from ground.*/
+orb::Orbit real_fake_ground_data(int controlcycle){
+    static orb::Orbit r=gracestart;
+    switch (controlcycle)
+    {
+    case 100:
+        //return an old orbit
+        r=gracestart;
+        return r;
+        break;
+    case 110:
+        //return an old orbit
+        r.startpropagating(r.nsgpstime()+100'000'000'000ULL,earth_rate_ecef);
+        r.finishpropagating();
+        return r;
+        break;
+    case 112:
+        //return an old orbit
+        r.startpropagating(r.nsgpstime()+1'000'000'000ULL,earth_rate_ecef);
+        r.finishpropagating();
+        return r;
+        break;
+    case 113:
+        //return an old orbit
+        r.startpropagating(r.nsgpstime()+20'000'000'000ULL,earth_rate_ecef);
+        r.finishpropagating();
+        return r;
+        break;
+    case 400:
+        //return an old orbit
+        r= grace100s;
+        r.startpropagating(r.nsgpstime()+1000'000'000'000ULL,earth_rate_ecef);
+        r.finishpropagating();
+        return r;
+        break;
+    default:
+        return orb::Orbit();
+        break;
+    }
+}
+
+
+void test_normal_use() {
+    orb::GroundPropagator est;
+    uint64_t gpsns= uint64_t(gnc::constant::init_gps_week_number)*gnc::constant::NANOSECONDS_IN_WEEK;
+    gpsns+= 1000'000'000'000ULL;
+    uint64_t dtgpsns= 120'000'000ULL;
+    //start est with an up to date current estimate.
+    est.input(orb::Orbit(gpsns,gracestart.recef(),gracestart.vecef()),gpsns,earth_rate_ecef);
+    orb::Orbit best= est.bestestimate();
+    TEST_ASSERT_TRUE(best.valid());
+    TEST_ASSERT_FALSE(best.numgravcallsleft());
+    for (int controlcycle=0; controlcycle<1000; controlcycle++){
+        gpsns+=dtgpsns;
+        orb::Orbit ground_data= real_fake_ground_data(controlcycle);
+        est.input(ground_data,gpsns,earth_rate_ecef);
+        est.onegravcall();
+        est.onegravcall();
+        est.onegravcall();
+        est.onegravcall();
+        orb::Orbit best= est.bestestimate();
+        //assert that the orbit never gets invalid or propagating
+        TEST_ASSERT_TRUE(best.valid());
+        TEST_ASSERT_FALSE(best.numgravcallsleft());
+    }
+    orb::Orbit lastsentorbit= grace100s;
+    lastsentorbit.startpropagating(gpsns,earth_rate_ecef);
+    lastsentorbit.finishpropagating();
+    best= est.bestestimate();
+    TEST_ASSERT_TRUE(best.valid());
+    TEST_ASSERT_FALSE(best.numgravcallsleft());
+    TEST_ASSERT_TRUE(best.nsgpstime()==lastsentorbit.nsgpstime());
+    PAN_TEST_ASSERT_LIN_3VECT_WITHIN(1E-8, best.vecef(), lastsentorbit.vecef());
+    PAN_TEST_ASSERT_LIN_3VECT_WITHIN(1E-5, best.recef(), lastsentorbit.recef());
+}
+
+void test_time_going_backwards() {
+    orb::GroundPropagator est;
+    uint64_t gpsns= uint64_t(gnc::constant::init_gps_week_number)*gnc::constant::NANOSECONDS_IN_WEEK;
+    gpsns+= 1000'000'000'000ULL;
+    //Time is going backwards for some reason???
+    int64_t dtgpsns= -120'000'000LL;
+    //start est with an up to date current estimate.
+    est.input(orb::Orbit(gpsns,gracestart.recef(),gracestart.vecef()),gpsns,earth_rate_ecef);
+    orb::Orbit best= est.bestestimate();
+    TEST_ASSERT_TRUE(best.valid());
+    TEST_ASSERT_FALSE(best.numgravcallsleft());
+    for (int controlcycle=0; controlcycle<1000; controlcycle++){
+        gpsns+=dtgpsns;
+        orb::Orbit ground_data= real_fake_ground_data(controlcycle);
+        est.input(ground_data,gpsns,earth_rate_ecef);
+        est.onegravcall();
+        est.onegravcall();
+        est.onegravcall();
+        est.onegravcall();
+        orb::Orbit best= est.bestestimate();
+        //assert that the orbit never gets invalid or propagating
+        TEST_ASSERT_TRUE(best.valid());
+        TEST_ASSERT_FALSE(best.numgravcallsleft());
+    }
+    orb::Orbit lastsentorbit= grace100s;
+    lastsentorbit.startpropagating(gpsns,earth_rate_ecef);
+    lastsentorbit.finishpropagating();
+    best= est.bestestimate();
+    TEST_ASSERT_TRUE(best.valid());
+    TEST_ASSERT_FALSE(best.numgravcallsleft());
+    TEST_ASSERT_TRUE(best.nsgpstime()==lastsentorbit.nsgpstime());
+    PAN_TEST_ASSERT_LIN_3VECT_WITHIN(1E-6, best.vecef(), lastsentorbit.vecef());
+    PAN_TEST_ASSERT_LIN_3VECT_WITHIN(1E-3, best.recef(), lastsentorbit.recef());
+}
+
+void test_lots_of_ground_data() {
+    orb::GroundPropagator est;
+    uint64_t gpsns= uint64_t(gnc::constant::init_gps_week_number)*gnc::constant::NANOSECONDS_IN_WEEK;
+    gpsns+= 1000'000'000'000ULL;
+    int64_t dtgpsns= 120'000'000LL;
+    //start est with an up to date current estimate.
+    est.input(orb::Orbit(gpsns,gracestart.recef(),gracestart.vecef()),gpsns,earth_rate_ecef);
+    orb::Orbit best= est.bestestimate();
+    TEST_ASSERT_TRUE(best.valid());
+    TEST_ASSERT_FALSE(best.numgravcallsleft());
+    for (int controlcycle=0; controlcycle<1000; controlcycle++){
+        gpsns+=dtgpsns;
+        orb::Orbit ground_data= gracestart;//ground data sent every controll cycle
+        est.input(ground_data,gpsns,earth_rate_ecef);
+        est.onegravcall();
+    }
+    //because there is only one grav call per control cycle the propagator can never catch up.
+    orb::Orbit lastsentorbit= orb::Orbit(gracestart.nsgpstime()+1000'000'000'000ULL,gracestart.recef(),gracestart.vecef());
+    lastsentorbit.startpropagating(gpsns,earth_rate_ecef);
+    lastsentorbit.finishpropagating();
+    best= est.bestestimate();
+    TEST_ASSERT_TRUE(best.valid());
+    TEST_ASSERT_FALSE(best.numgravcallsleft());
+    TEST_ASSERT_TRUE(best.nsgpstime()==lastsentorbit.nsgpstime());
+    PAN_TEST_ASSERT_LIN_3VECT_WITHIN(1E-6, best.vecef(), lastsentorbit.vecef());
+    PAN_TEST_ASSERT_LIN_3VECT_WITHIN(1E-3, best.recef(), lastsentorbit.recef());
+}
+
+void test_lots_of_ground_data_catchingup() {
+    orb::GroundPropagator est;
+    uint64_t gpsns= uint64_t(gnc::constant::init_gps_week_number)*gnc::constant::NANOSECONDS_IN_WEEK;
+    gpsns+= 1000'000'000'000ULL;
+    int64_t dtgpsns= 120'000'000LL;
+    //start est with an up to date current estimate.
+    est.input(orb::Orbit(gpsns,gracestart.recef(),gracestart.vecef()),gpsns,earth_rate_ecef);
+    orb::Orbit best= est.bestestimate();
+    TEST_ASSERT_TRUE(best.valid());
+    TEST_ASSERT_FALSE(best.numgravcallsleft());
+    for (int controlcycle=0; controlcycle<1000; controlcycle++){
+        gpsns+=dtgpsns;
+        orb::Orbit ground_data= gracestart;//ground data sent every controll cycle
+        est.input(ground_data,gpsns,earth_rate_ecef);
+        est.onegravcall();
+        est.onegravcall();
+    }
+    //because there is two grav calls per control cycle the propagator can catch up.
+    orb::Orbit lastsentorbit= gracestart;
+    lastsentorbit.startpropagating(gpsns,earth_rate_ecef);
+    lastsentorbit.finishpropagating();
+    best= est.bestestimate();
+    TEST_ASSERT_TRUE(best.valid());
+    TEST_ASSERT_FALSE(best.numgravcallsleft());
+    TEST_ASSERT_TRUE(best.nsgpstime()==lastsentorbit.nsgpstime());
+    PAN_TEST_ASSERT_LIN_3VECT_WITHIN(1E-6, best.vecef(), lastsentorbit.vecef());
+    PAN_TEST_ASSERT_LIN_3VECT_WITHIN(1E-3, best.recef(), lastsentorbit.recef());
+}
+
+void test_edge_cases() {
+    orb::GroundPropagator est;
+    uint64_t t0= gracestart.nsgpstime();
+    lin::Vector3d r0= gracestart.recef();
+    lin::Vector3d v0= gracestart.vecef();
+    est.input(orb::Orbit(t0+100,r0,v0),t0,earth_rate_ecef);
+    orb::Orbit best= est.bestestimate();
+    TEST_ASSERT_TRUE(best.valid());
+    TEST_ASSERT_EQUAL_INT(best.numgravcallsleft(),1);
+
+    est.input(orb::Orbit(t0,r0,v0),t0,earth_rate_ecef);
+    best= est.bestestimate();
+    TEST_ASSERT_TRUE(best.valid());
+    TEST_ASSERT_FALSE(best.numgravcallsleft());
+    TEST_ASSERT_FALSE(est.totalnumgravcallsleft());
+    TEST_ASSERT_TRUE(best.nsgpstime()==t0);
+
+    est.input(orb::Orbit(t0,r0,v0),t0,earth_rate_ecef);
+    best= est.bestestimate();
+    TEST_ASSERT_TRUE(best.valid());
+    TEST_ASSERT_FALSE(best.numgravcallsleft());
+    TEST_ASSERT_FALSE(est.totalnumgravcallsleft());
+    TEST_ASSERT_TRUE(best.nsgpstime()==t0);
+
+    est.input(orb::Orbit(t0-100,r0,v0),t0,earth_rate_ecef);
+    best= est.bestestimate();
+    TEST_ASSERT_TRUE(best.valid());
+    TEST_ASSERT_FALSE(best.numgravcallsleft());
+    TEST_ASSERT_EQUAL_INT(est.totalnumgravcallsleft(),1);
+    TEST_ASSERT_TRUE(best.nsgpstime()==t0);
+
+    est.input(orb::Orbit(t0-1'000'000'000LL,r0,v0),t0,earth_rate_ecef);
+    best= est.bestestimate();
+    TEST_ASSERT_TRUE(best.valid());
+    TEST_ASSERT_FALSE(best.numgravcallsleft());
+    TEST_ASSERT_TRUE(est.totalnumgravcallsleft()>1);
+    TEST_ASSERT_TRUE(best.nsgpstime()==t0);
+
+    est.input(orb::Orbit(t0+100LL,r0,v0),t0-1'000'000'000LL,earth_rate_ecef);
+    best= est.bestestimate();
+    TEST_ASSERT_TRUE(best.valid());
+    TEST_ASSERT_TRUE(best.numgravcallsleft());
+    TEST_ASSERT_TRUE(est.totalnumgravcallsleft()>1);
+    best.startpropagating(t0-100,earth_rate_ecef);
+    TEST_ASSERT_FALSE(best.numgravcallsleft());
+    TEST_ASSERT_TRUE(best.nsgpstime()==t0-100);
+
+    est.input(orb::Orbit(),t0+100LL,earth_rate_ecef);
+    best= est.bestestimate();
+    TEST_ASSERT_TRUE(best.valid());
+    TEST_ASSERT_FALSE(best.numgravcallsleft());
+    TEST_ASSERT_TRUE(est.totalnumgravcallsleft()==0);
+    TEST_ASSERT_TRUE(best.nsgpstime()==t0+100);
+
+    est.resetorbits();
+    best= est.bestestimate();
+    TEST_ASSERT_FALSE(best.valid());
+
+}
+
+int test_orbit() {
+    UNITY_BEGIN();
+    RUN_TEST(test_basic_constructors);
+    RUN_TEST(test_normal_use);
+    RUN_TEST(test_time_going_backwards);
+    RUN_TEST(test_lots_of_ground_data);
+    RUN_TEST(test_lots_of_ground_data_catchingup);
+    RUN_TEST(test_edge_cases);
+    return UNITY_END();
+}
+
+
+#ifdef DESKTOP
+int main(int argc, char *argv[]) {
+    return test_orbit();
+}
+#else
+#include <Arduino.h>
+void setup() {
+    delay(10000);
+    Serial.begin(9600);
+    test_orbit();
+}
+
+void loop() {}
+#endif


### PR DESCRIPTION
# Ground Propagator

Fixes #181 

### Summary of changes
- Added a GroundPropagator class to propagate orbits sent from ground.
- Added to docs of `Orbit::numgravcallsleft()` that it returns 0 if the Orbit is invalid.

### Ptest Effects
None

### Testing
Unit tests are in `test_groundpropagator.cpp`
Let me know if there is some edge case I'm missing that might break the estimator.

Under normal conditions, this estimator just propagates the most recently uplinked Orbit.

The main goal of the testing is to ensure there is no input that will break the estimator so it can't recover if ground does eventually uplink a good Orbit, and the sat is given enough time to propagate it to the current time.

Also the testing should ensure that too many Orbits getting uplinked won't overload the estimator and prevent it from making progress.

### Documentation Evidence
Inline documentation is sufficient.