### PR TITLE
Fix MEX file errors on Arch Linux

### DIFF
--- a/MATLAB/generate_mex_code.m
+++ b/MATLAB/generate_mex_code.m
@@ -5,5 +5,5 @@ geograv_incl = strcat('-I', fullfile(filepath, "../geograv/include"));
 geomag_file = fullfile(filepath, "environmental_models/helper_functions/geomag_wrapper.cpp");
 geograv_file = fullfile(filepath, "environmental_models/helper_functions/geograv_wrapper.cpp");
 
-mex("-R2018a", "CXXFLAGS=$CXXFLAGS -std=c++14", geomag_file, geomag_incl);
-mex("-R2018a", "CXXFLAGS=$CXXFLAGS -std=c++14", geograv_file, geograv_incl);
+try mex("-R2018a", "CXXFLAGS=$CXXFLAGS -std=c++14", geomag_file, geomag_incl); catch; end
+try mex("-R2018a", "CXXFLAGS=$CXXFLAGS -std=c++14", geograv_file, geograv_incl); catch; end


### PR DESCRIPTION
# Fix MEX file errors on Arch Linux

Fixes #MEX file compilation is carried out successfully and the correct MEX files are generated, however on Arch Linux an error is thrown after the compilation is complete.184

### Summary of changes
- MEX file compilation is carried out successfully and the correct MEX files are generated, however on Arch Linux an error is thrown after the compilation is complete. To fix this, I added try catch statements around each MEX call in generate_mex_code.

### Ptest Effects
None, except that ptest cases requiring MATLAB will now run on Arch Linux.

### Testing
Deleting the MEX files and running main.m produces no errors, and the MEX files are generated.

### Constants
None


### Documentation Evidence
None
