### PR TITLE
Potter Algorithm for Square Root Kalman Filter

### DIFF
--- a/include/orb/kalman_utl.h
+++ b/include/orb/kalman_utl.h
@@ -68,7 +68,7 @@ void matrix_hypot(const lin::Matrix<T,N,N>& A,const lin::Matrix<T,N,N>& B,lin::M
  * z= A*x + noise with variance 1.0/(invstddiv*invstddiv)
  * The measurement noise is assumed to be independent zero mean gaussian
  * @param[in,out] x: State estimate
- * @param[in,out] S: square root covariance
+ * @param[in,out] S: square root covariance P= S*S^T
  * @param[in] z: Measurement
  * @param[in] A: Measurement coefficents
  * @param[in] invstddiv(finite): Inverse of measurement standard diviation
@@ -79,7 +79,7 @@ void potter_measurement_update(lin::Vector<T,N>& x, lin::Matrix<T,N,N>& S, const
     lin::Vector<T,N> v= lin::transpose(A*S);//n^2
     v= v*invstddiv;
     T sigma= one/(lin::fro(v)+one);
-    T delta= (z-A*x)*invstddiv;// predicted residuals 
+    T delta= (z-lin::dot(A,x))*invstddiv;// predicted residuals 
     lin::Vector<T,N> K= S*v;//n^2
     x= x+K*(delta*sigma);
     T gamma= sigma/(one+std::sqrt(sigma));

--- a/include/orb/kalman_utl.h
+++ b/include/orb/kalman_utl.h
@@ -61,4 +61,23 @@ void matrix_hypot(const lin::Matrix<T,N,N>& A,const lin::Matrix<T,N,N>& B,lin::M
     lin::qr(M, junk, C);
 }
 
+/**
+ * Potter Algorithm as described in
+ * "Factorization Methods for Discrete Sequential Estimation, Volume 128"
+ * Appendix II.E
+ * z= A*x + noise variance sigma
+ * @param[in,out] x: State estimate
+ * @param[in,out] S: square root covariance
+ * @param[in] z: Measurement
+ * @param[in] A: Measurement coefficents
+ * @param[in] sigma: Measurement variance
+ */
+template <typename T, lin::size_t N>
+void potter_measurement_update(lin::Vector<T,N>& x,lin::Matrix<T,N,N>& S,const T& z,const lin::RowVector<T,N>& A,const T& sigma){
+    
 }
+
+
+
+
+} //namespace orb

--- a/include/orb/kalman_utl.h
+++ b/include/orb/kalman_utl.h
@@ -63,14 +63,15 @@ void matrix_hypot(const lin::Matrix<T,N,N>& A,const lin::Matrix<T,N,N>& B,lin::M
 
 /**
  * Potter Algorithm as described in
- * "Factorization Methods for Discrete Sequential Estimation, Volume 128"
+ * "Factorization Methods for Discrete Sequential Estimation", by Gerald J. Bierman
  * Appendix II.E
- * z= A*x + noise variance sigma
+ * z= A*x + noise with variance 1.0/(invstddiv*invstddiv)
+ * The measurement noise is assumed to be independent zero mean gaussian
  * @param[in,out] x: State estimate
  * @param[in,out] S: square root covariance
  * @param[in] z: Measurement
  * @param[in] A: Measurement coefficents
- * @param[in] invstddiv: Inverse of measurement standard diviation
+ * @param[in] invstddiv(finite): Inverse of measurement standard diviation
  */
 template <typename T, lin::size_t N>
 void potter_measurement_update(lin::Vector<T,N>& x, lin::Matrix<T,N,N>& S, const T& z, const lin::RowVector<T,N>& A, const T& invstddiv){

--- a/include/orb/kalman_utl.h
+++ b/include/orb/kalman_utl.h
@@ -70,11 +70,19 @@ void matrix_hypot(const lin::Matrix<T,N,N>& A,const lin::Matrix<T,N,N>& B,lin::M
  * @param[in,out] S: square root covariance
  * @param[in] z: Measurement
  * @param[in] A: Measurement coefficents
- * @param[in] sigma: Measurement variance
+ * @param[in] invstddiv: Inverse of measurement standard diviation
  */
 template <typename T, lin::size_t N>
-void potter_measurement_update(lin::Vector<T,N>& x,lin::Matrix<T,N,N>& S,const T& z,const lin::RowVector<T,N>& A,const T& sigma){
-    
+void potter_measurement_update(lin::Vector<T,N>& x, lin::Matrix<T,N,N>& S, const T& z, const lin::RowVector<T,N>& A, const T& invstddiv){
+    T one= 1;
+    lin::Vector<T,N> v= lin::transpose(A*S);//n^2
+    v= v*invstddiv;
+    T sigma= one/(lin::fro(v)+one);
+    T delta= (z-A*x)*invstddiv;// predicted residuals 
+    lin::Vector<T,N> K= S*v;//n^2
+    x= x+K*(delta*sigma);
+    T gamma= sigma/(one+std::sqrt(sigma));
+    S= S-(gamma*K)*lin::transpose(v);//n^2
 }
 
 

--- a/test/test_kalman_utl/test_kalman_utl.cpp
+++ b/test/test_kalman_utl/test_kalman_utl.cpp
@@ -51,15 +51,42 @@ void test_matrix_hypot() {
 
 
 void test_potter_measurement_update(){
+    // function [x,P] = kalman_correction_step(x,y,H,P,R)
+    // % correction step of kalman filter, see canx paper eq 4.4 - 4.7
+    // %get kalman gain K
+    // K= P*H'/(H*P*H'+ R);
+    // P= (eye(length(x))-K*H)*P*(eye(length(x))-K*H)'+K*R*K';
+    // x= x + K*(y-H*x);
+    // end
     lin::internal::RandomsGenerator const rand(0);
     {
-    lin::Matrixf<8, 8> S;
-    for (int i = 0; i < 25; i++) {
-        S= lin::rands<decltype(S)>(S.rows(), S.cols(), rand);
-        B= lin::rands<decltype(A)>(A.rows(), A.cols(), rand);
-        orb::matrix_hypot(A,B,C);
-        TEST_ASSERT_FLOAT_WITHIN(1E-10, 0.0,lin::fro(lin::transpose(C)*C-lin::transpose(A)*A-lin::transpose(B)*B));
-    }
+        typedef float realtype;
+        constexpr static int N=8;
+        lin::Matrix<realtype,N, N> S;
+        lin::Matrix<realtype,N, N> P;
+        lin::Vector<realtype,N> x;
+        lin::Vector<realtype,N> x_test;
+        lin::RowVector<realtype,N> A;
+        realtype invstddiv;
+        realtype z;
+        for (int i = 0; i < 25; i++) {
+            S= lin::rands<decltype(S)>(S.rows(), S.cols(), rand);
+            P= S*lin::transpose(S);
+            A= lin::rands<decltype(A)>(A.rows(), A.cols(), rand);
+            x= lin::rands<decltype(x)>(x.rows(), x.cols(), rand);
+            x_test=x;
+            lin::Vectorf<2> B= lin::rands<lin::Vectorf<2>>(2, 1, rand);
+            invstddiv= std::abs(B(0));
+            z= B(1);
+            orb::potter_measurement_update(x_test,S,z,A,invstddiv);
+            // now use regular kalman update
+            realtype R= (1/invstddiv)*(1/invstddiv);
+            lin::Vector<realtype,N> K= P*lin::transpose(A)/(lin::dot(A*P,lin::transpose(A))+R);
+            P= ((lin::identity<realtype,N>()-K*A)*P*lin::transpose(lin::identity<realtype,N>()-K*A)+K*R*lin::transpose(K)).eval();
+            x= (x + K*(z-lin::dot(A,x))).eval();
+            TEST_ASSERT_FLOAT_WITHIN(1E-10, 0.0,lin::fro(x_test-x));
+            TEST_ASSERT_FLOAT_WITHIN(1E-10, 0.0,lin::fro(P-S*lin::transpose(S)));
+        }
     }
 
 }
@@ -68,6 +95,7 @@ void test_potter_measurement_update(){
 int test_kalman_utl() {
     UNITY_BEGIN();
     RUN_TEST(test_matrix_hypot);
+    RUN_TEST(test_potter_measurement_update);
     return UNITY_END();
 }
 

--- a/test/test_kalman_utl/test_kalman_utl.cpp
+++ b/test/test_kalman_utl/test_kalman_utl.cpp
@@ -50,6 +50,21 @@ void test_matrix_hypot() {
 }
 
 
+void test_potter_measurement_update(){
+    lin::internal::RandomsGenerator const rand(0);
+    {
+    lin::Matrixf<8, 8> S;
+    for (int i = 0; i < 25; i++) {
+        S= lin::rands<decltype(S)>(S.rows(), S.cols(), rand);
+        B= lin::rands<decltype(A)>(A.rows(), A.cols(), rand);
+        orb::matrix_hypot(A,B,C);
+        TEST_ASSERT_FLOAT_WITHIN(1E-10, 0.0,lin::fro(lin::transpose(C)*C-lin::transpose(A)*A-lin::transpose(B)*B));
+    }
+    }
+
+}
+
+
 int test_kalman_utl() {
     UNITY_BEGIN();
     RUN_TEST(test_matrix_hypot);


### PR DESCRIPTION
# Potter Algorithm for Square Root Kalman Filter

Fixes #199 

### Summary of changes
- `potter_measurement_update` function
This is a more stable version of the regular Kalman filter update for square root covariance and scalar measurements with independent noise.

### Testing
Randomized unit testing.


### Documentation Evidence
Inline documentation is sufficient.
