### PR TITLE
More Orbit Valid Checks

### DIFF
--- a/include/gnc/constants.hpp
+++ b/include/gnc/constants.hpp
@@ -76,7 +76,7 @@ GNC_TRACKED_CONSTANT(constexpr static float, J_wheel, 135.0e-7f);
 
 GNC_TRACKED_CONSTANT(constexpr static float, w_wheel_max, 677.0f);
 
-GNC_TRACKED_CONSTANT(constexpr static uint64_t, NANOSECONDS_IN_WEEK, 7ULL*24ULL*60ULL*60ULL*1'000'000'000ULL);
+GNC_TRACKED_CONSTANT(constexpr static int64_t, NANOSECONDS_IN_WEEK, 7ULL*24ULL*60ULL*60ULL*1'000'000'000ULL);
 
 }  // namespace constant
 }  // namespace gnc

--- a/include/orb/GroundPropagator.h
+++ b/include/orb/GroundPropagator.h
@@ -92,7 +92,7 @@ class GroundPropagator {
      * @param[in] gps_time_ns: Time to propagate to (ns).
      * @param[in] earth_rate_ecef: The earth's angular rate in ecef frame ignored for orbits already propagating(rad/s).
      */
-    void input(const Orbit& ground_data, const uint64_t& gps_time_ns, const lin::Vector3d& earth_rate_ecef){
+    void input(const Orbit& ground_data, const int64_t& gps_time_ns, const lin::Vector3d& earth_rate_ecef){
         //start propagators
         current.startpropagating(gps_time_ns,earth_rate_ecef);
         catching_up.startpropagating(gps_time_ns,earth_rate_ecef);

--- a/include/orb/Orbit.h
+++ b/include/orb/Orbit.h
@@ -133,7 +133,8 @@ class Orbit {
             if (!(_ns_gps_time >= MINGPSTIME_NS)) goto INVALID;
             //position check
             lin::Vector3f recef_f=_recef;
-            float r2= lin::fro(recef_f);
+            float r2= lin::fro(recef_f);//lin::fro is Frobenius (aka Euclidean) norm squared
+            //r2 is r^2
             //note if position is NAN, these checks will fail.
             if (!(r2 <= MAXORBITRADIUS*MAXORBITRADIUS)) goto INVALID;
             if (!(r2 >= MINORBITRADIUS*MINORBITRADIUS)) goto INVALID;
@@ -143,8 +144,9 @@ class Orbit {
             lin::Vector3f vecef0_f=_vecef;
             vecef0_f= vecef0_f + lin::Vector3f({-w*recef_f(1),w*recef_f(0),0.0f});
             //e is the specific orbital energy
+            //lin::fro is Frobenius (aka Euclidean) norm squared
             float e= lin::fro(vecef0_f)*0.5f-mu/std::sqrt(r2);
-            //h2 is norm sqaured of specific orbital angular momentum
+            //h2 is norm squared of specific orbital angular momentum
             float h2= lin::fro(lin::cross(recef_f,vecef0_f));
             //ep and ea are the lowest specific orbital energy if h2 is the same at max and min radius
             float ep= h2*(0.5f/(MINORBITRADIUS*MINORBITRADIUS))-mu/MINORBITRADIUS;

--- a/include/orb/Orbit.h
+++ b/include/orb/Orbit.h
@@ -79,10 +79,7 @@ class Orbit {
     /// \private
     /** Validity of the orbit.
      * A valid orbit has finite and real position and velocity, is in low
-     * earth orbit, and has a reasonable time stamp (within 20 years of pan epoch).
-     * The validity check should not reject
-     * gps readings due to reasonable noise of:
-     * TODO add max expected gps error see issue #372
+     * earth orbit, and has a reasonable time stamp within MAXGPSTIME_NS, MINGPSTIME_NS.
      *
      * Low earth orbit is a Orbit that stays between MINORBITRADIUS and MAXORBITRADIUS.
      */

--- a/test/test_groundpropagator/test_groundpropagator.cpp
+++ b/test/test_groundpropagator/test_groundpropagator.cpp
@@ -28,13 +28,13 @@
            } while(0) 
 
 //grace orbit initial
-const orb::Orbit gracestart(uint64_t(gnc::constant::init_gps_week_number)*gnc::constant::NANOSECONDS_IN_WEEK,{-6522019.833240811L, 2067829.846415895L, 776905.9724453629L},{941.0211143841228L, 85.66662333729801L, 7552.870253470936L});
+const orb::Orbit gracestart(int64_t(gnc::constant::init_gps_week_number)*gnc::constant::NANOSECONDS_IN_WEEK,{-6522019.833240811L, 2067829.846415895L, 776905.9724453629L},{941.0211143841228L, 85.66662333729801L, 7552.870253470936L});
 
 //grace orbit 100 seconds later
-const orb::Orbit grace100s(uint64_t(gnc::constant::init_gps_week_number)*gnc::constant::NANOSECONDS_IN_WEEK+100'000'000'000ULL,{-6388456.55330517L, 2062929.296577276L, 1525892.564091281L},{1726.923087560988L, -185.5049475128178L, 7411.544615026139L});
+const orb::Orbit grace100s(int64_t(gnc::constant::init_gps_week_number)*gnc::constant::NANOSECONDS_IN_WEEK+100'000'000'000ULL,{-6388456.55330517L, 2062929.296577276L, 1525892.564091281L},{1726.923087560988L, -185.5049475128178L, 7411.544615026139L});
 
 //grace orbit 13700 seconds later
-const orb::Orbit grace13700s(uint64_t(gnc::constant::init_gps_week_number)*gnc::constant::NANOSECONDS_IN_WEEK+13700'000'000'000ULL,{1579190.147083268L, -6066459.613667888L, 2785708.976728437L},{480.8261476296949L, -3083.977113497177L, -6969.470748202005L});
+const orb::Orbit grace13700s(int64_t(gnc::constant::init_gps_week_number)*gnc::constant::NANOSECONDS_IN_WEEK+13700'000'000'000ULL,{1579190.147083268L, -6066459.613667888L, 2785708.976728437L},{480.8261476296949L, -3083.977113497177L, -6969.470748202005L});
 
 //earth rate in ecef (rad/s)
 lin::Vector3d earth_rate_ecef= {0.000000707063506E-4,-0.000001060595259E-4,0.729211585530000E-4};
@@ -645,7 +645,7 @@ void test_four_inputs_h() {
     est.input(x0,gracestart.nsgpstime(),earth_rate_ecef);
     est.input(x1,gracestart.nsgpstime(),earth_rate_ecef);
     est.input(x2,gracestart.nsgpstime(),earth_rate_ecef);
-    uint64_t t= gracestart.nsgpstime()-3200'000'000'000LL;
+    int64_t t= gracestart.nsgpstime()-3200'000'000'000LL;
     est.input(x3,t,earth_rate_ecef);
     CHECKINVARIANT(est);
     TEST_ASSERT(est.current.valid());
@@ -675,7 +675,7 @@ void test_four_inputs_i() {
     est.input(x0,gracestart.nsgpstime(),earth_rate_ecef);
     est.input(x1,gracestart.nsgpstime(),earth_rate_ecef);
     est.input(x2,gracestart.nsgpstime(),earth_rate_ecef);
-    uint64_t t= gracestart.nsgpstime()-2200'000'000'000LL;
+    int64_t t= gracestart.nsgpstime()-2200'000'000'000LL;
     est.input(x3,t,earth_rate_ecef);
     CHECKINVARIANT(est);
     TEST_ASSERT(est.current.valid());
@@ -694,7 +694,7 @@ void test_four_inputs_i() {
 void test_one_orbit_prop() {
     orb::GroundPropagator est;
     orb::Orbit x0= gracestart;
-    uint64_t t0= gracestart.nsgpstime();
+    int64_t t0= gracestart.nsgpstime();
     est.input(x0,t0,earth_rate_ecef);
     auto est_copy= est;
     TEST_ASSERT_FALSE(est.total_num_grav_calls_left());
@@ -721,7 +721,7 @@ void test_one_orbit_prop() {
 /** Test that propagator can't be overloaded.*/
 void test_overloading() {
     orb::GroundPropagator est;
-    uint64_t t0= gracestart.nsgpstime();
+    int64_t t0= gracestart.nsgpstime();
     lin::Vector3d v0= gracestart.vecef();
     lin::Vector3d r0= gracestart.recef();
     orb::Orbit x0(t0,r0,v0);
@@ -797,9 +797,9 @@ orb::Orbit real_fake_ground_data(int controlcycle){
 
 void test_normal_use() {
     orb::GroundPropagator est;
-    uint64_t gpsns= uint64_t(gnc::constant::init_gps_week_number)*gnc::constant::NANOSECONDS_IN_WEEK;
+    int64_t gpsns= int64_t(gnc::constant::init_gps_week_number)*gnc::constant::NANOSECONDS_IN_WEEK;
     gpsns+= 1000'000'000'000ULL;
-    uint64_t dtgpsns= 120'000'000ULL;
+    int64_t dtgpsns= 120'000'000ULL;
     //start est with an up to date current estimate.
     est.input(orb::Orbit(gpsns,gracestart.recef(),gracestart.vecef()),gpsns,earth_rate_ecef);
     orb::Orbit best= est.best_estimate();
@@ -831,7 +831,7 @@ void test_normal_use() {
 
 void test_time_going_backwards() {
     orb::GroundPropagator est;
-    uint64_t gpsns= uint64_t(gnc::constant::init_gps_week_number)*gnc::constant::NANOSECONDS_IN_WEEK;
+    int64_t gpsns= int64_t(gnc::constant::init_gps_week_number)*gnc::constant::NANOSECONDS_IN_WEEK;
     gpsns+= 1000'000'000'000ULL;
     //Time is going backwards for some reason???
     int64_t dtgpsns= -120'000'000LL;
@@ -866,7 +866,7 @@ void test_time_going_backwards() {
 
 void test_lots_of_ground_data() {
     orb::GroundPropagator est;
-    uint64_t gpsns= uint64_t(gnc::constant::init_gps_week_number)*gnc::constant::NANOSECONDS_IN_WEEK;
+    int64_t gpsns= int64_t(gnc::constant::init_gps_week_number)*gnc::constant::NANOSECONDS_IN_WEEK;
     gpsns+= 1000'000'000'000ULL;
     int64_t dtgpsns= 120'000'000LL;
     //start est with an up to date current estimate.
@@ -894,7 +894,7 @@ void test_lots_of_ground_data() {
 
 void test_lots_of_ground_data_catchingup() {
     orb::GroundPropagator est;
-    uint64_t gpsns= uint64_t(gnc::constant::init_gps_week_number)*gnc::constant::NANOSECONDS_IN_WEEK;
+    int64_t gpsns= int64_t(gnc::constant::init_gps_week_number)*gnc::constant::NANOSECONDS_IN_WEEK;
     gpsns+= 1000'000'000'000ULL;
     int64_t dtgpsns= 120'000'000LL;
     //start est with an up to date current estimate.

--- a/test/test_orbit/test_orbit.cpp
+++ b/test/test_orbit/test_orbit.cpp
@@ -72,25 +72,10 @@ lin::Vector3d earth_rate_ecef= {0.000000707063506E-4,-0.000001060595259E-4,0.729
 void test_basic_constructors() {
     orb::Orbit x;
     TEST_ASSERT_FALSE(x.valid());
-
     //test valid orbit
     TEST_ASSERT_TRUE(gracestart.valid());
     x=gracestart;
     TEST_ASSERT_TRUE(x.valid());
-
-    //test invalid orbit
-    lin::Vector3d r2 {0.0L, 0.0L, 0.0L};
-    lin::Vector3d v2 {941.0211143841228L, 85.66662333729801L, 7552.870253470936L};
-    int64_t t2= int64_t(gnc::constant::init_gps_week_number)*gnc::constant::NANOSECONDS_IN_WEEK;
-    orb::Orbit y2(t2,r2,v2);
-    TEST_ASSERT_FALSE(y2.valid());
-
-    //test NAN invalid orbit
-    lin::Vector3d r3 {0.0, gnc::constant::nan, 0.0};
-    lin::Vector3d v3 {941.0211143841228L, 85.66662333729801L, 7552.870253470936L};
-    int64_t t3= int64_t(gnc::constant::init_gps_week_number)*gnc::constant::NANOSECONDS_IN_WEEK;
-    orb::Orbit y3(t3,r3,v3);
-    TEST_ASSERT_FALSE(y3.valid());
 }
 
 
@@ -102,7 +87,84 @@ void test_applydeltav() {
     TEST_ASSERT_TRUE(y.vecef()(0)==942.0211143841228 );
     TEST_ASSERT_TRUE(y.vecef()(1)==87.66662333729801 );
     TEST_ASSERT_TRUE(y.vecef()(2)==7555.870253470936 );
-    //TODO add more valid checks for applying dv that make the orbit invalid.
+}
+
+void test_validity_checks () {
+    int64_t panepoch= int64_t(gnc::constant::init_gps_week_number)*gnc::constant::NANOSECONDS_IN_WEEK;
+    orb::Orbit y;
+    double x;
+
+    //time checks to fail
+    y=orb::Orbit(orb::MINGPSTIME_NS-1LL,gracestart.recef(),gracestart.vecef());
+    TEST_ASSERT_FALSE(y.valid());
+    y=orb::Orbit(orb::MAXGPSTIME_NS+1LL,gracestart.recef(),gracestart.vecef());
+    TEST_ASSERT_FALSE(y.valid());
+    y=orb::Orbit(0LL,gracestart.recef(),gracestart.vecef());
+    TEST_ASSERT_FALSE(y.valid());
+    y=orb::Orbit(-1LL,gracestart.recef(),gracestart.vecef());
+    TEST_ASSERT_FALSE(y.valid());
+
+    //time checks to pass
+    y=orb::Orbit(orb::MINGPSTIME_NS,gracestart.recef(),gracestart.vecef());
+    TEST_ASSERT_TRUE(y.valid());
+    y=orb::Orbit(orb::MAXGPSTIME_NS,gracestart.recef(),gracestart.vecef());
+    TEST_ASSERT_TRUE(y.valid());
+    y=orb::Orbit(panepoch,gracestart.recef(),gracestart.vecef());
+    TEST_ASSERT_TRUE(y.valid());
+
+    //position checks to fail
+    y=orb::Orbit(panepoch,{0.0,0.0,0.0},gracestart.vecef());
+    TEST_ASSERT_FALSE(y.valid());
+    y=orb::Orbit(panepoch,{0.0, gnc::constant::nan,0.0},gracestart.vecef());
+    TEST_ASSERT_FALSE(y.valid());
+    y=orb::Orbit(panepoch,{0.0,(double)orb::MAXORBITRADIUS+10.0,0.0},gracestart.vecef());
+    TEST_ASSERT_FALSE(y.valid());
+    x= (double)orb::MAXORBITRADIUS/std::sqrt(3.0)+10.0;
+    y=orb::Orbit(panepoch,{x,x,x},gracestart.vecef());
+    TEST_ASSERT_FALSE(y.valid());
+    y=orb::Orbit(panepoch,{0.0,(double)orb::MINORBITRADIUS-10.0,0.0},gracestart.vecef());
+    TEST_ASSERT_FALSE(y.valid());
+    x= (double)orb::MINORBITRADIUS/std::sqrt(3.0)-10.0;
+    y=orb::Orbit(panepoch,{x,x,x},gracestart.vecef());
+    TEST_ASSERT_FALSE(y.valid());
+    
+    //position checks to pass
+    y=orb::Orbit(panepoch,gracestart.recef(),gracestart.vecef());
+    TEST_ASSERT_TRUE(y.valid());
+
+    //orbit checks to fail
+    y=orb::Orbit(panepoch,gracestart.recef(),{0.0,0.0,0.0});
+    TEST_ASSERT_FALSE(y.valid());
+    y=orb::Orbit(panepoch,gracestart.recef(),{0.0,gnc::constant::nan,0.0});
+    TEST_ASSERT_FALSE(y.valid());
+    y=orb::Orbit(panepoch,gracestart.recef(),{0.0,1.0E5,0.0});
+    TEST_ASSERT_FALSE(y.valid());
+    y=orb::Orbit(panepoch,gracestart.recef(),{0.0,1.0E10,0.0});
+    TEST_ASSERT_FALSE(y.valid());
+    y=orb::Orbit(panepoch,gracestart.recef(),{0.0,4.0E3,0.0});
+    TEST_ASSERT_FALSE(y.valid());
+    y=orb::Orbit(panepoch,gracestart.recef(),-1.0E-3*gracestart.recef());
+    TEST_ASSERT_FALSE(y.valid());
+
+    //orbit checks to pass
+    y=orb::Orbit(panepoch,gracestart.recef(),gracestart.vecef());
+    TEST_ASSERT_TRUE(y.valid());
+    y=orb::Orbit(panepoch,gracestart.recef(),-gracestart.vecef());
+    TEST_ASSERT_TRUE(y.valid());
+    y=orb::Orbit(panepoch,gracestart.recef(),gracestart.vecef()+lin::Vector3d({0.0,10.0,0.0}));
+    TEST_ASSERT_TRUE(y.valid());
+    y=orb::Orbit(panepoch,gracestart.recef(),gracestart.vecef()*(1.0-1.0E-3));
+    TEST_ASSERT_TRUE(y.valid());
+
+    //test validity is checked in applydeltav
+    y=orb::Orbit(panepoch,gracestart.recef(),gracestart.vecef());
+    TEST_ASSERT_TRUE(y.valid());
+    y.applydeltav({0.0,gnc::constant::nan,0.0});
+    TEST_ASSERT_FALSE(y.valid());
+    y=orb::Orbit(panepoch,gracestart.recef(),gracestart.vecef());
+    TEST_ASSERT_TRUE(y.valid());
+    y.applydeltav({0.0,1.0E6,0.0});
+    TEST_ASSERT_FALSE(y.valid());
 }
 
 void test_calc_geograv() {
@@ -547,6 +609,7 @@ int test_orbit() {
     UNITY_BEGIN();
     RUN_TEST(test_basic_constructors);
     RUN_TEST(test_applydeltav);
+    RUN_TEST(test_validity_checks);
     RUN_TEST(test_calc_geograv);
     RUN_TEST(test_specificenergy);
     RUN_TEST(test_shortupdate_a);

--- a/test/test_orbit/test_orbit.cpp
+++ b/test/test_orbit/test_orbit.cpp
@@ -58,13 +58,13 @@ T det(const lin::Matrix<T, 0, 0, MR, MR>& x){
 }
 
 //grace orbit initial
-const orb::Orbit gracestart(uint64_t(gnc::constant::init_gps_week_number)*gnc::constant::NANOSECONDS_IN_WEEK,{-6522019.833240811L, 2067829.846415895L, 776905.9724453629L},{941.0211143841228L, 85.66662333729801L, 7552.870253470936L});
+const orb::Orbit gracestart(int64_t(gnc::constant::init_gps_week_number)*gnc::constant::NANOSECONDS_IN_WEEK,{-6522019.833240811L, 2067829.846415895L, 776905.9724453629L},{941.0211143841228L, 85.66662333729801L, 7552.870253470936L});
 
 //grace orbit 100 seconds later
-const orb::Orbit grace100s(uint64_t(gnc::constant::init_gps_week_number)*gnc::constant::NANOSECONDS_IN_WEEK+100'000'000'000ULL,{-6388456.55330517L, 2062929.296577276L, 1525892.564091281L},{1726.923087560988L, -185.5049475128178L, 7411.544615026139L});
+const orb::Orbit grace100s(int64_t(gnc::constant::init_gps_week_number)*gnc::constant::NANOSECONDS_IN_WEEK+100'000'000'000ULL,{-6388456.55330517L, 2062929.296577276L, 1525892.564091281L},{1726.923087560988L, -185.5049475128178L, 7411.544615026139L});
 
 //grace orbit 13700 seconds later
-const orb::Orbit grace13700s(uint64_t(gnc::constant::init_gps_week_number)*gnc::constant::NANOSECONDS_IN_WEEK+13700'000'000'000ULL,{1579190.147083268L, -6066459.613667888L, 2785708.976728437L},{480.8261476296949L, -3083.977113497177L, -6969.470748202005L});
+const orb::Orbit grace13700s(int64_t(gnc::constant::init_gps_week_number)*gnc::constant::NANOSECONDS_IN_WEEK+13700'000'000'000ULL,{1579190.147083268L, -6066459.613667888L, 2785708.976728437L},{480.8261476296949L, -3083.977113497177L, -6969.470748202005L});
 
 //earth rate in ecef (rad/s)
 lin::Vector3d earth_rate_ecef= {0.000000707063506E-4,-0.000001060595259E-4,0.729211585530000E-4};
@@ -81,14 +81,14 @@ void test_basic_constructors() {
     //test invalid orbit
     lin::Vector3d r2 {0.0L, 0.0L, 0.0L};
     lin::Vector3d v2 {941.0211143841228L, 85.66662333729801L, 7552.870253470936L};
-    uint64_t t2= uint64_t(gnc::constant::init_gps_week_number)*gnc::constant::NANOSECONDS_IN_WEEK;
+    int64_t t2= int64_t(gnc::constant::init_gps_week_number)*gnc::constant::NANOSECONDS_IN_WEEK;
     orb::Orbit y2(t2,r2,v2);
     TEST_ASSERT_FALSE(y2.valid());
 
     //test NAN invalid orbit
     lin::Vector3d r3 {0.0, gnc::constant::nan, 0.0};
     lin::Vector3d v3 {941.0211143841228L, 85.66662333729801L, 7552.870253470936L};
-    uint64_t t3= uint64_t(gnc::constant::init_gps_week_number)*gnc::constant::NANOSECONDS_IN_WEEK;
+    int64_t t3= int64_t(gnc::constant::init_gps_week_number)*gnc::constant::NANOSECONDS_IN_WEEK;
     orb::Orbit y3(t3,r3,v3);
     TEST_ASSERT_FALSE(y3.valid());
 }
@@ -340,7 +340,7 @@ void test_shortupdate_g() {
  * Test startpropagating scheduals the correct numgravcalls
  */
 void test_startnumgravcalls(){
-    uint64_t startns= gracestart.nsgpstime();
+    int64_t startns= gracestart.nsgpstime();
     orb::Orbit y;
     TEST_ASSERT_EQUAL_INT(0,y.numgravcallsleft());
     y= gracestart;
@@ -510,7 +510,7 @@ void test_resetfinaltime(){
 
 /** A semi realistic case of what could happen on flight.*/
 void test_semirealistic_update(){
-    uint64_t gpstime=gracestart.nsgpstime()+10000'000'000'000LL;
+    int64_t gpstime=gracestart.nsgpstime()+10000'000'000'000LL;
     int controlcycle=0;
     orb::Orbit y=gracestart; //10'000s old Orbit data sent from ground
     while(y.numgravcallsleft() || y.nsgpstime()!=gracestart.nsgpstime()+13700'000'000'000LL){

--- a/tools/constants.csv
+++ b/tools/constants.csv
@@ -28,4 +28,4 @@ true,float,pointer_Kp,20.0e-4f
 true,float,pointer_Kd,22.5e-4f
 false,float,J_wheel,135.0e-7f
 false,float,w_wheel_max,677.0f
-false,uint64_t,NANOSECONDS_IN_WEEK,7ULL*24ULL*60ULL*60ULL*1'000'000'000ULL
+false,int64_t,NANOSECONDS_IN_WEEK,7ULL*24ULL*60ULL*60ULL*1'000'000'000ULL


### PR DESCRIPTION
# More Orbit Valid Checks

### Summary of changes
- Added more Orbit validity checks.
I tried to approximately check that the Orbit will stay between `MINORBITRADIUS` and `MAXORBITRADIUS` using specific orbital energy and specific orbital angular momentum. 
- Changed the gps time in nanoseconds from `uint64_t` to `int64_t`

### Testing
Added more unit tests in `test_validity_checks()`

### Constants
I added MAXGPSTIME_NS and MINGPSTIME_NS
which are about 20 years before and after PAN epoch, Orbits are invalid if they have a time outside this range.

### Documentation Evidence
Inline documentation is sufficient.
