### PR TITLE
Updated Environment Model Docs and Added Gravity Model

### DIFF
--- a/include/gnc/environment.hpp
+++ b/include/gnc/environment.hpp
@@ -82,7 +82,7 @@ void earth_attitude(double t, lin::Vector4f &q_ecef_eci);
  *
  *  @ingroup environment
  */
-void earth_angular_rate(double t, lin::Vector3d &w_eci);
+void earth_angular_rate(double t, lin::Vector3d &w_ecef);
 
 /** @brief Determines Earth's angular rate.
  *

--- a/include/gnc/environment.hpp
+++ b/include/gnc/environment.hpp
@@ -87,7 +87,7 @@ void earth_angular_rate(double t, lin::Vector3d &w_ecef);
 /** @brief Determines Earth's angular rate.
  *
  *  @param[in]  t     Time in seconds since the PAN epoch.
- *  @param[out] w_eci Earth's angular rate (units of radians per second).
+ *  @param[out] w_ecef Earth's angular rate (units of radians per second).
  *
  *  @internal
  *  Currently, the time input is extraneous as this function only looks at Earth's

--- a/include/gnc/environment.hpp
+++ b/include/gnc/environment.hpp
@@ -98,7 +98,7 @@ void earth_angular_rate(double t, lin::Vector3d &w_ecef);
  *
  *  @ingroup environment
  */
-void earth_angular_rate(double t, lin::Vector3f &w_eci);
+void earth_angular_rate(double t, lin::Vector3f &w_ecef);
 
 /** @brief Models gravitational acceleration and potential due to Earth.
  * 

--- a/include/gnc/environment.hpp
+++ b/include/gnc/environment.hpp
@@ -71,7 +71,7 @@ void earth_attitude(double t, lin::Vector4f &q_ecef_eci);
 /** @brief Determines Earth's angular rate.
  *
  *  @param[in]  t     Time in seconds since the PAN epoch.
- *  @param[out] w_eci Earth's angular rate (units of radians per second).
+ *  @param[out] w_ecef Earth's angular rate (units of radians per second).
  *
  *  @internal
  *  Currently, the time input is extraneous as this function only looks at Earth's

--- a/include/gnc/environment.hpp
+++ b/include/gnc/environment.hpp
@@ -1,5 +1,36 @@
+//
+// MIT License
+//
+// Copyright (c) 2020 Pathfinder for Autonomous Navigation (PAN)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
 /** @file gnc/environment.hpp
- *  @author Kyle Krol */
+ *  @author Kyle Krol
+ */
+
+/** @defgroup environment Environment
+ *  @brief Contains environmental modules used throughout the rest of GNC.
+ * 
+ *  More details to come...
+ */
 
 #ifndef GNC_ENVIRONMENT_HPP_
 #define GNC_ENVIRONMENT_HPP_
@@ -9,38 +40,145 @@
 namespace gnc {
 namespace env {
 
-/** @fn earth_attitude
- *  @param[in]  t Time in seconds since the PAN epoch.
- *  @param[out] q Quaternion to transform vectors from ECI to ECEF.
- *  @{ */
-void earth_attitude(double t, lin::Vector4d &q);
-void earth_attitude(double t, lin::Vector4f &q);
-/** @} */
+/** @brief Determines earth's current attitude represented as a quaternion.
+ *
+ *  @param[in]  t          Time in seconds since the PAN epoch.
+ *  @param[out] q_ecef_eci Earth's attitude represented as a quaternion.
+ * 
+ *  The returned quaternion represents the rotation transforming from ECI to ECEF.
+ *  This representation will be most accurate around the PAN epoch.
+ * 
+ *  @sa env::earth_attitude(double, lin::Vector4d &)
+ * 
+ *  @ingroup environment
+ */
+void earth_attitude(double t, lin::Vector4d &q_ecef_eci);
 
-/** @fn earth_angular_rate
- *  @param[in]  t Time in seconds since the PAN epoch.
- *  @param[out] w Angular rate to transform vectors from ECI to ECEF.
- *  @{ */
-void earth_angular_rate(double t, lin::Vector3d &w);
-void earth_angular_rate(double t, lin::Vector3f &w);
-/** @} */
+/** @brief Determines earth's current attitude represented as a quaternion.
+ *
+ *  @param[in]  t          Time in seconds since the PAN epoch.
+ *  @param[out] q_ecef_eci Earth's attitude represented as a quaternion.
+ * 
+ *  The returned quaternion represents the rotation transforming from ECI to ECEF.
+ *  This representation will be most accurate around the PAN epoch.
+ * 
+ *  @sa env::earth_attitude(double, lin::Vector4f &)
+ * 
+ *  @ingroup environment
+ */
+void earth_attitude(double t, lin::Vector4f &q_ecef_eci);
 
-/** @fn sun_vector
- *  @param[in]  t Time in seconds since the PAN epoch.
- *  @param[out] s Normalized vector from Earth the Sun in the ECI frame.
- *  @{ */
-void sun_vector(double t, lin::Vector3f &s);
-void sun_vector(double t, lin::Vector3d &s);
-/** @} */
+/** @brief Determines Earth's angular rate.
+ *
+ *  @param[in]  t     Time in seconds since the PAN epoch.
+ *  @param[out] w_eci Earth's angular rate (units of radians per second).
+ *
+ *  @internal
+ *  Currently, the time input is extraneous as this function only looks at Earth's
+ *  rate about the z-axis and doesn't model precession/nutation.
+ *  @endinternal
+ *
+ *  @sa env::earth_angular_rate(double, lin::Vector3f)
+ *
+ *  @ingroup environment
+ */
+void earth_angular_rate(double t, lin::Vector3d &w_eci);
 
-/** @fn magnetic_field
- *  @param[in]  t Time in seconds since the PAN epoch.
- *  @param[in]  r Position in the ECEF frame with units of meters.
- *  @param[out] b Magnetic field in the ECEF frame with units of Tesla.
- *  @{ */
-void magnetic_field(double t, lin::Vector3d const &r, lin::Vector3f &b);
-void magnetic_field(double t, lin::Vector3d const &r, lin::Vector3d &b);
-/** @} */
+/** @brief Determines Earth's angular rate.
+ *
+ *  @param[in]  t     Time in seconds since the PAN epoch.
+ *  @param[out] w_eci Earth's angular rate (units of radians per second).
+ *
+ *  @internal
+ *  Currently, the time input is extraneous as this function only looks at Earth's
+ *  rate about the z-axis and doesn't model precession/nutation.
+ *  @endinternal
+ *
+ *  @sa env::earth_angular_rate(double, lin::Vector3d)
+ *
+ *  @ingroup environment
+ */
+void earth_angular_rate(double t, lin::Vector3f &w_eci);
+
+/** @brief Models gravitational acceleration and potential due to Earth.
+ * 
+ *  @param[in]  r_ecef Position (units of meters)
+ *  @param[out] g      Gravitational acceleration in ECEF (units of m/s^2).
+ *  @param[out] U      Gravitational potential (units of J/kg).
+ * 
+ *  The calculation is done using a fourth order spherical harmonic expansion of
+ *  Earth's gravitational potential.
+ * 
+ *  @sa env::gravity(lin::Vector3d const &, lin::Vector3d &, double &)
+ * 
+ *  @ingroup environment
+ */
+void gravity(lin::Vector3d const &r_ecef, lin::Vector3f &g_ecef, float &U_ecef);
+
+/** @brief Models gravitational acceleration and potential due to Earth.
+ * 
+ *  @param[in]  r_ecef Position (units of meters)
+ *  @param[out] g_ecef Gravitational acceleration (units of m/s^2).
+ *  @param[out] U_ecef Gravitational potential (units of J/kg).
+ * 
+ *  The calculation is done using a fourth order spherical harmonic expansion of
+ *  Earth's gravitational potential.
+ * 
+ *  @sa env::gravity(lin::Vector3d const &, lin::Vector3f &, float &)
+ * 
+ *  @ingroup environment
+ */
+void gravity(lin::Vector3d const &r_ecef, lin::Vector3d &g_ecef, double &U_ecef);
+
+/** @brief Predicts the vector pointing from Earth to the sun.
+ * 
+ *  @param[in]  t     Time in seconds since the PAN epoch.
+ *  @param[out] s_eci Vector pointing from Earth to the sun in ECI (unit vector).
+ * 
+ *  This vector is commonly taken as the "sat to sun" vector throughout GNC code.
+ * 
+ *  @sa env::sun_vector(double, lin::Vector3d &)
+ * 
+ *  @ingroup environment
+ */
+void sun_vector(double t, lin::Vector3f &s_eci);
+
+/** @brief Predicts the vector pointing from Earth to the sun.
+ * 
+ *  @param[in]  t     Time in seconds since the PAN epoch.
+ *  @param[out] s_eci Vector pointing from Earth to the sun in ECI (unit vector).
+ * 
+ *  This vector is commonly taken as the "sat to sun" vector throughout GNC code.
+ * 
+ *  @sa env::sun_vector(double, lin::Vector3f &)
+ * 
+ *  @ingroup environment
+ */
+void sun_vector(double t, lin::Vector3d &s_eci);
+
+/** @brief Models Earth's magnetic field as a function of time and position.
+ * 
+ *  @param[in] t      Time in seconds since the PAN epoch.
+ *  @param[in] r_ecef Position (units of meters).
+ *  @param[in] b_ecef Magnetic field (units of Tesla).
+ * 
+ *  @sa env::magnetic_field(double, lin::Vector3d const &, lin::Vector3d &)
+ * 
+ *  @ingroup environment
+ */
+void magnetic_field(double t, lin::Vector3d const &r_ecef, lin::Vector3f &b_ecef);
+
+/** @brief Models Earth's magnetic field as a function of time and position.
+ * 
+ *  @param[in] t      Time in seconds since the PAN epoch.
+ *  @param[in] r_ecef Position (units of meters).
+ *  @param[in] b_ecef Magnetic field (units of Tesla).
+ * 
+ *  @sa env::magnetic_field(double, lin::Vector3d const &, lin::Vector3f &)
+ * 
+ *  @ingroup environment
+ */
+void magnetic_field(double t, lin::Vector3d const &r_ecef, lin::Vector3d &b_ecef);
 
 }  // namespace env
 }  // namespace gnc

--- a/src/gnc_environment.cpp
+++ b/src/gnc_environment.cpp
@@ -6,6 +6,9 @@
 #include <gnc/environment.hpp>
 #include <gnc/utilities.hpp>
 
+#include <orb/geograv.hpp>
+#include <orb/GGM05S.hpp>
+
 #include <cmath>
 
 #include "inl/geomag.hpp"
@@ -13,7 +16,7 @@
 namespace gnc {
 namespace env {
 
-void earth_attitude(double t, lin::Vector4d &q) {
+void earth_attitude(double t, lin::Vector4d &q_ecef_eci) {
   // Determine a transformation from ecef0 to ecef0p
   lin::Vector4d q_ecef0p_ecef0({  // Small angle approx sin(x) ~ x
     t * constant::earth_precession_rate(0),
@@ -33,60 +36,82 @@ void earth_attitude(double t, lin::Vector4d &q) {
   // Rotate through ECI -> ECEF0 -> ECEF0P -> ECEF
   lin::Vector4d temp;
   utl::quat_cross_mult(q_ecef0p_ecef0, constant::q_ecef0_eci, temp);
-  utl::quat_cross_mult(q_ecef_ecef0p, temp, q);
+  utl::quat_cross_mult(q_ecef_ecef0p, temp, q_ecef_eci);
 }
 
-void earth_attitude(double t, lin::Vector4f &q) {
-  lin::Vector4d _q;
-  earth_attitude(t, _q);
-  for (lin::size_t i = 0; i < q.size(); i++)
-      q(i) = static_cast<float>(_q(i));
+void earth_attitude(double t, lin::Vector4f &q_ecef_eci) {
+  lin::Vector4d _q_ecef_eci;
+  earth_attitude(t, _q_ecef_eci);
+  q_ecef_eci = _q_ecef_eci;
 }
 
-void earth_angular_rate(double t, lin::Vector3d &w) {
-  w = { 0.0, 0.0, constant::earth_rate_ecef_z };
+void earth_angular_rate(double t, lin::Vector3d &w_eci) {
+  w_eci = { 0.0, 0.0, constant::earth_rate_ecef_z };
 }
 
-void earth_angular_rate(double t, lin::Vector3f &w) {
-  w = { 0.0, 0.0, constant::earth_rate_ecef_z };
+void earth_angular_rate(double t, lin::Vector3f &w_eci) {
+  w_eci = { 0.0, 0.0, constant::earth_rate_ecef_z };
+}
+
+void gravity(lin::Vector3d const &r_ecef, lin::Vector3f &g_ecef, float &U_ecef) {
+  double _U_ecef;
+  lin::Vector3d _g_ecef;
+  gravity(r_ecef, _g_ecef, _U_ecef);
+  g_ecef = _g_ecef;
+  U_ecef = _U_ecef;
+}
+
+void gravity(lin::Vector3d const &r_ecef, lin::Vector3d &g_ecef, double &U_ecef) {
+  // Setup the gravity model at compile time
+  GNC_TRACKED_CONSTANT(constexpr static int, env_grav_order, 4);
+  constexpr static geograv::Coeff<env_grav_order> env_grav_model = static_cast<geograv::Coeff<env_grav_order>>(GGM05S);
+
+  // Make a call to the model
+  geograv::Vector in;
+  geograv::Vector g;
+  in.x = r_ecef(0);
+  in.y = r_ecef(1);
+  in.z = r_ecef(2);
+  U_ecef = geograv::GeoGrav(in, g, env_grav_model, true);
+  g_ecef = { g.x, g.y, g.z };
 }
 
 // t will never get large enough for floating point precession to be an issue
-void sun_vector(double t, lin::Vector3f &s) {
+void sun_vector(double t, lin::Vector3f &s_eci) {
   // Calculate Earth's position in the perifocal frame
   float E = static_cast<float>(constant::two_pi) * (static_cast<float>(t) -
       static_cast<float>(constant::earth_perihelion_time)) / static_cast<float>(constant::earth_period);
   E = E + static_cast<float>(constant::earth_eccentricity) * sinf(E);
-  s = {  // Negative of Earth's position (want to point at the Sun)
+  s_eci = {  // Negative of Earth's position (want to point at the Sun)
     static_cast<float>(constant::earth_eccentricity) - cosf(E),
     sinf(E) * (0.5f * static_cast<float>(constant::earth_eccentricity) * static_cast<float>(constant::earth_eccentricity) - 1.0f),
     0.0f
   };
-  s = s / lin::norm(s);  // Puts us in AU (approximately) and is a normalized vector
+  s_eci = s_eci / lin::norm(s_eci);  // Puts us in AU (approximately) and is a normalized vector
   // Rotate into ECI
   lin::Vector4f q_eci_perifocal_f = constant::q_eci_perifocal;
-  utl::rotate_frame(q_eci_perifocal_f, s);
+  utl::rotate_frame(q_eci_perifocal_f, s_eci);
 }
 
-void sun_vector(double t, lin::Vector3d &s) {
-  lin::Vector3f _s;
-  sun_vector(t, _s);
-  s = _s;
+void sun_vector(double t, lin::Vector3d &s_eci) {
+  lin::Vector3f _s_eci;
+  sun_vector(t, _s_eci);
+  s_eci = _s_eci;
 }
 
-void magnetic_field(double t, lin::Vector3d const &r, lin::Vector3f &b) {
+void magnetic_field(double t, lin::Vector3d const &r_ecef, lin::Vector3f &b_ecef) {
   geomag::Vector in, out;
-  in.x = r(0);
-  in.y = r(1);
-  in.z = r(2);
+  in.x = r_ecef(0);
+  in.y = r_ecef(1);
+  in.z = r_ecef(2);
   out = geomag::GeoMag(constant::init_dec_year + t / (365.0 * 24.0 * 60.0 * 60.0),in, geomag::WMM2020);
-  b = { out.x, out.y, out.z };
+  b_ecef = { out.x, out.y, out.z };
 }
 
-void magnetic_field(double t, lin::Vector3d const &r, lin::Vector3d &b) {
-  lin::Vector3f _b;
-  magnetic_field(t, r, _b);
-  b = _b;
+void magnetic_field(double t, lin::Vector3d const &r_ecef, lin::Vector3d &b_ecef) {
+  lin::Vector3f _b_ecef;
+  magnetic_field(t, r_ecef, _b_ecef);
+  b_ecef = _b_ecef;
 }
 }  // namespace env
 }  // namespace gnc

--- a/src/gnc_environment.cpp
+++ b/src/gnc_environment.cpp
@@ -1,5 +1,30 @@
+//
+// MIT License
+//
+// Copyright (c) 2020 Pathfinder for Autonomous Navigation (PAN)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
 /** @file gnc_environment.cpp
- *  @author Kyle Krol */
+ *  @author Kyle Krol
+ */
 
 #include <gnc/config.hpp>
 #include <gnc/constants.hpp>

--- a/test/test_all/environment_test.cpp
+++ b/test/test_all/environment_test.cpp
@@ -1,5 +1,3 @@
-/** @file test_all/environmental_test.cpp
- *  @author Kyle Krol */
 
 #include "test.hpp"
 #include "environment_test.hpp"

--- a/test/test_all/environment_test.cpp
+++ b/test/test_all/environment_test.cpp
@@ -55,6 +55,29 @@ void test_environment_earth_attitude() {
   }));
 }
 
+void test_environment_gravity() {
+  double U_ecef;
+  lin::Vector3d r_ecef, g_ecef;
+  // Testing expected outputs against MATLAB
+  r_ecef = { 5.43092e6, 2.949986e6, 2.949986e6 };
+  gnc::env::gravity(r_ecef, g_ecef, U_ecef);
+  TEST_ASSERT_DOUBLE_VEC_NEAR(1e-5, g_ecef, lin::Vector3d({
+    -6.740640681994386,
+    -3.661468338734510,
+    -3.671706398469697
+  }));
+  TEST_ASSERT_DOUBLE_WITHIN(1e2, U_ecef, 5.821618371493001e7);
+  // Testing expected outputs against MATLAB
+  r_ecef = { -2.949986e6, 5.43092e6, 2.949986e6 };
+  gnc::env::gravity(r_ecef, g_ecef, U_ecef);
+  TEST_ASSERT_DOUBLE_VEC_NEAR(1e-5, g_ecef, lin::Vector3d({
+     3.661197091703317,
+    -6.740691015633035,
+    -3.671820564640941
+  }));
+  TEST_ASSERT_DOUBLE_WITHIN(1e2, U_ecef, 5.821613652050869e7);
+}
+
 void test_environment_sun_vector() {
   lin::Vector3f s;
   // Calculate and check for t=0.0 (comparing against MATLAB)
@@ -110,6 +133,7 @@ void test_environment_magnetic_field() {
 
 void environment_test() {
   RUN_TEST(test_environment_earth_attitude);
+  RUN_TEST(test_environment_gravity);
   RUN_TEST(test_environment_sun_vector);
   RUN_TEST(test_environment_magnetic_field);
 }


### PR DESCRIPTION

# Update Environment Model Docs and Add Gravity Model

### Summary of changes
- Added a 4th order gravity model (like MATLAB) to the GNC environment models. This will be used soon for the orbit controller implementation and we don't quite need the accuracy orbit estimation requires.
- Updated the documentation for the environment models to conform better with doxygen. I wrapped them up in an environment module and will do the same for the utility functions, attitude estimator, etc soon.

### Ptest Effects
NA

### Testing
I added a unit test comparing the model to MATLAB. Given this essentially calls the same exact model, however, there isn't a huge need for testing other than the spot checking added here.

### Constants

| Constant                 | Location             |
|--------------------------|----------------------|
|              env_grav_order            |       src/gnc_environment.cpp         |


### Documentation Evidence
Inline docs should be good.
