### PR TITLE
teensy tests passing

### DIFF
--- a/test/custom_assertions.hpp
+++ b/test/custom_assertions.hpp
@@ -2,6 +2,10 @@
 #define CUSTOM_ASSERTIONS_HPP_
 
 #include <unity.h>
+#undef isnan
+#undef isinf
+#undef isfinite
+#undef abs
 
 #define PAN_TEST_ASSERT_EQUAL_FLOAT_ARR(expected, actual, delta, n) { \
     char err_str[25]; \

--- a/test/test_kalman_utl/test_kalman_utl.cpp
+++ b/test/test_kalman_utl/test_kalman_utl.cpp
@@ -2,12 +2,12 @@
 #include <cstdint>
 #include <limits>
 #include <lin.hpp>
-#include "../custom_assertions.hpp"
 #include <orb/kalman_utl.h>
 #ifndef DESKTOP
 #include <Arduino.h>
 #endif
 #include <unity.h>
+#include "../custom_assertions.hpp"
 
 void test_matrix_hypot() {
     lin::internal::RandomsGenerator const rand(0);


### PR DESCRIPTION
# Quick Fix to Get Teensy36 Tests to Pass

Fixes #212 

### Summary of changes
- Reverted to an older version of lin
- Added some `#undef`s to stop Arduino's annoying macros.

### Testing
teensy36 tests pass now.
