### PR TITLE
Update MATLAB to use int64 GPS time and real control cycle duration.

### DIFF
--- a/MATLAB/README.md
+++ b/MATLAB/README.md
@@ -61,6 +61,8 @@ Most Matlab types are compatible with python types: [Python to Matlab function i
  * `./estimator_prototypes/*` - prototypes for estimators.
  * `./orbit_propagator_prototypes/*` - prototypes for orbit propagators.
  * `./orbit_estimation/*` - orbit estimator, main initialization, run, and some helper and test functions.
+ * `./estimator_test_file_gen/*` - scripts and helper functions to generate hdf5 estimator test files from the MATLAB sim
+
 
 ## Main State Data Structure
 
@@ -87,7 +89,7 @@ Each satellites state has the following members and submembers:
    * `magrod_hysteresis_body`(3x1 matrix): Real magnetorquer hysteresis moment (Am^2)
    * `ground_position_ecef`(3x1 matrix): ground known estimated position of the satellite (m)
    * `ground_velocity_ecef`(3x1 matrix): ground known estimated velocity of the gps reciever of the satellite (m/s)
-   * `ground_time`(scalar): ground known estimated time since initial GPS week (s)
+   * `ground_gpstime`(scalar int64): ground known estimated time since GPS epoch (ns)
  * `sensors`
    * `gyro_bias`: (rad/s)
    * `magnetometer_bias`: (T)
@@ -135,11 +137,12 @@ sensor readings is a struct with elements:
  * `sat2sun_body`, unit vector from satellite to sun (unitless)
  * `sun_sensor_true`, true if sun vector reading is good, else false.
  * `wheel_momentum_body`, wheel angular momentum reading (Nms)
- * `time`, time since initial GPS week (s)
+ * `gpstime`(scalar int64): time since GPS epoch (ns)
  * `position_ecef`, position of the gps reciever of the satellite (m)
  * `velocity_ecef`, velocity of the gps reciever of the satellite (m/s)
- * `target_position_ecef`, position of the target gps reciever of the satellite, from ground (m)
- * `target_velocity_ecef`, velocity of the target gps reciever of the satellite, from ground (m/s)
+ * `target_position_ecef`, position of the target satellite, from ground (m)
+ * `target_velocity_ecef`, velocity of the target satellite, from ground (m/s)
+ * `target_gpstime`(scalar int64): time since GPS epoch, from ground (ns)
  * `relative_position_ecef`, position vector from self to target, from cdgps (m)
 
 actuator commands is a struct with elements:
@@ -151,7 +154,7 @@ actuator commands is a struct with elements:
  * `magrod_moment`, commanded x,y,z magnetorquer moments (Am^2)
  * `position_ecef`(3x1 matrix): estimated position of the satellite to send to ground (m)
  * `velocity_ecef`(3x1 matrix): estimated velocity of the satellite to send to ground (m/s)
- * `time`(scalar): time since initial GPS week, time of the orbit estimate to send to ground (s)
+ * `gpstime`(scalar int64): time since GPS epoch, time of the orbit estimate to send to ground (ns)
 
 ## Functions
 
@@ -242,6 +245,8 @@ Constants are stored in the `const` global struct.
    * `mu`(positive scalar), Earth's gravitational constant (m^3/s^2)
    * `dt`(positive int64), Simulation timestep (ns)
    * `INITGPS_WN`(positive int), Initial gps week number, epoch for time (weeks)
+   * `INIT_DYEAR`(double): Decimal year at INITGPS_WN epoch (year, AD)
+   * `INIT_GPSNS`(int64): INITGPS_WN in nanoseconds (ns)
    * `R_EARTH`(positive scalar), Equatorial Radius of Earth (m)
    * `e_earth`(positive scalar), Earth's eccentricity
    * `tp_earth`(scalar), Time when earth was at perihelion (s)

--- a/MATLAB/README.md
+++ b/MATLAB/README.md
@@ -61,7 +61,6 @@ Most Matlab types are compatible with python types: [Python to Matlab function i
  * `./estimator_prototypes/*` - prototypes for estimators.
  * `./orbit_propagator_prototypes/*` - prototypes for orbit propagators.
  * `./orbit_estimation/*` - orbit estimator, main initialization, run, and some helper and test functions.
- * `./estimator_test_file_gen/*` - scripts and helper functions to generate hdf5 estimator test files from the MATLAB sim
 
 
 ## Main State Data Structure

--- a/MATLAB/actuator_command.m
+++ b/MATLAB/actuator_command.m
@@ -18,7 +18,7 @@ satellite_state.actuators.wheel_commanded_ramp=abs(actuator_commands.wheel_torqu
 if (satellite_state.sensors.gps_time_till_lock<=0 && rand()<const.probability_of_ground_gps)
     satellite_state.actuators.ground_position_ecef= actuator_commands.position_ecef;
     satellite_state.actuators.ground_velocity_ecef= actuator_commands.velocity_ecef;
-    satellite_state.actuators.ground_time= actuator_commands.time;
+    satellite_state.actuators.ground_gpstime= actuator_commands.gpstime;
 end
 end
 

--- a/MATLAB/actuators_off_command.m
+++ b/MATLAB/actuators_off_command.m
@@ -10,7 +10,7 @@ function actuator_commands = actuators_off_command()
 %  * `magrod_moment`, commanded x,y,z magnetorquer moments (Am^2)
 %  * `position_ecef`(3x1 matrix): estimated position of the satellite (m)
 %  * `velocity_ecef`(3x1 matrix): estimated velocity of the gps reciever of the satellite (m/s)
-%  * `time`(scalar): estimated time since initial GPS week (s)
+%  * `gpstime`(scalar int64): time since GPS epoch, time of the orbit estimate to send to ground (ns)
 actuator_commands= struct();
 actuator_commands.firing_start_times= inf(4,1);
 actuator_commands.firing_on_times= zeros(4,1);

--- a/MATLAB/actuators_off_state.m
+++ b/MATLAB/actuators_off_state.m
@@ -12,7 +12,7 @@ function actuators = actuators_off_state()
 %    * `magrod_hysteresis_body`(3x1 matrix): Real magnetorquer hysteresis moment (Am^2)
 %    * `ground_position_ecef`(3x1 matrix): ground known estimated position of the satellite (m)
 %    * `ground_velocity_ecef`(3x1 matrix): ground known estimated velocity of the gps reciever of the satellite (m/s)
-%    * `ground_time`(scalar): ground known estimated time since initial GPS week (s)
+%    * `ground_gpstime`(scalar int64): ground known estimated time since GPS epoch (ns)
 actuators=struct();
 actuators.firing_start_times= inf(4,1);
 actuators.thrust_vectors_body= zeros(3,4);
@@ -24,6 +24,6 @@ actuators.magrod_real_moment_body= zeros(3,1);
 actuators.magrod_hysteresis_body= zeros(3,1);
 actuators.ground_position_ecef= nan(3,1);
 actuators.ground_velocity_ecef= nan(3,1);
-actuators.ground_time= nan;
+actuators.ground_gpstime= int64(0);
 end
 

--- a/MATLAB/config.m
+++ b/MATLAB/config.m
@@ -14,6 +14,9 @@ setup_path()
 const.INITGPS_WN= 2045;% positive int
 % initial gps week number, epoch for time.
 const.INIT_DYEAR= decyear(utl_time2datetime(0.0,const.INITGPS_WN));
+% Decimal year at INITGPS_WN epoch (year, AD)
+const.INIT_GPSNS= int64(const.INITGPS_WN)*int64(1E9)*int64(7*24*60*60);
+% INITGPS_WN in nanoseconds (ns)
 
 const.mu = 3986004.415e8;%3.986e14;% positive scalar
 % Earth's gravitational constant (m^3/s^2)
@@ -25,7 +28,7 @@ const.mu_sun = 1.32712440018E20; % positive scalar
 % Sun's gravitational constant (m^3/s^2)
 const.R_EARTH= 6378137.0;
 %Equatorial Radius of Earth (m)*/
-const.dt = int64(1e8);% positive int64
+const.dt = int64(120e6);% positive int64
 % Simulation timestep            (ns)
 const.e_earth = 0.0167086;
 % Earth's eccentricity.
@@ -93,11 +96,11 @@ const.JBINV=inv(const.JB);% 3x3 symmetric matrix
 % inverse of dry moment of inertia of satellite in body frame
 
 %% GPS sensor constants %%
-const.GPS_LOCK_TIME=0;%1*60;% (positive scalar):
+const.GPS_LOCK_TIME=1*60;% (positive scalar):
 %Time it takes the GPS to get a lock (s)
 const.CDGPS_LOCK_TIME=15*60;% (positive scalar):
 %Time it takes the CDGPS to get a lock (s)
-const.gps_max_angle= pi;%60*pi/180;% (positive scalar):
+const.gps_max_angle= 60*pi/180;% (positive scalar):
 % Max angle of gps antenna to radia out where gps can work (rad)
 const.cdgps_max_angle= 60*pi/180;% (positive scalar):
 % Max angle of cdgps antenna to other sat where cdgps can work (rad)

--- a/MATLAB/sensor_reading.m
+++ b/MATLAB/sensor_reading.m
@@ -42,16 +42,16 @@ eclipse = env_eclipse(true_state.position_eci,sat2sun_eci);
 sensor_readings.wheel_momentum_body= true_state.wheel_rate_body*const.JWHEEL;
 
 %% GPS
-sensor_readings.time= 0;
+sensor_readings.gpstime= int64(0);
 sensor_readings.position_ecef= nan(3,1);
 sensor_readings.velocity_ecef= nan(3,1);
 sensor_readings.self2target_position_ecef= nan(3,1);
 sensor_readings.target_velocity_ecef= nan(3,1);
 sensor_readings.target_position_ecef= nan(3,1);
-sensor_readings.target_time= 0;
+sensor_readings.target_gpstime= int64(0);
 
 if (my_satellite_state.sensors.gps_time_till_lock<=0)
-    sensor_readings.time= true_state.time;
+    sensor_readings.gpstime= true_state.time_ns+const.INIT_GPSNS;
     sensor_readings.position_ecef= position_ecef + randn(3,1)*const.gps_position_noise_sdiv+my_satellite_state.sensors.gps_position_bias_ecef;
     velocity_ecef= utl_rotateframe(quat_ecef_eci, true_state.velocity_eci)-cross(rate_ecef,position_ecef);
     sensor_readings.velocity_ecef= velocity_ecef + randn(3,1)*const.gps_velocity_noise_sdiv++my_satellite_state.sensors.gps_velocity_bias_ecef;
@@ -66,7 +66,7 @@ if (my_satellite_state.sensors.gps_time_till_lock<=0)
     if (rand()<const.probability_of_ground_gps)
         sensor_readings.target_position_ecef= other_satellite_state.actuators.ground_position_ecef;
         sensor_readings.target_velocity_ecef= other_satellite_state.actuators.ground_velocity_ecef;
-        sensor_readings.target_time= other_satellite_state.actuators.ground_time;
+        sensor_readings.target_gpstime= other_satellite_state.actuators.ground_gpstime;
     end
 end
 

--- a/MATLAB/update_FC_state.m
+++ b/MATLAB/update_FC_state.m
@@ -1,11 +1,6 @@
 function [state,actuators] = update_FC_state(state,sensor_readings)
 % Global variables treated as inputs:
 %  * const
-%  * sensors
-% 
-% Global variables treated as outputs:
-%  * actuators
-%  * 
 
 % attitude PD controller
 %   calculate commanded wheel torque
@@ -15,7 +10,7 @@ global const
 %% Orbit Estimation %%
 estimator.valid_gps_measure=all(isfinite([sensor_readings.position_ecef; sensor_readings.velocity_ecef;]));
 if (estimator.valid_gps_measure)
-    estimator.time_ns= int64(sensor_readings.time*1E9);
+    estimator.time_ns= sensor_readings.gpstime-const.INIT_GPSNS;
 else
     estimator.time_ns= state.orbit_est_state.time_ns+const.dt;
 end
@@ -32,7 +27,7 @@ estimator.time= double(estimator.time_ns)*1E-9;
     estimator.time_ns, ...
     sensor_readings.target_position_ecef, ...
     sensor_readings.target_velocity_ecef, ...
-    int64(sensor_readings.target_time*1E9)); 
+    sensor_readings.target_gpstime-const.INIT_GPSNS); 
 estimator.target_position_ecef= estimator.self2target_r_ecef+estimator.position_ecef;
 estimator.target_velocity_ecef= estimator.self2target_v_ecef+estimator.velocity_ecef;
 
@@ -70,7 +65,7 @@ end
 actuators= actuators_off_command();
 actuators.position_ecef= estimator.position_ecef;
 actuators.velocity_ecef= estimator.velocity_ecef;
-actuators.time= estimator.time;
+actuators.gpstime= estimator.time_ns+const.INIT_GPSNS;
 
 %these are the pointing commands, primary is optimized before secondary
 %everything must be a unit vector in the body frame, or NaN


### PR DESCRIPTION
# Update MATLAB to use int64 GPS time and real control cycle duration.

Fixes #213 

### Summary of changes
- actuators, actuator commands, and sensor readings now use `int64` ns from GPS epoch instead of `double` s from PAN epoch.
- Changed control cycle time from 100ms to 120ms to match flight software.
- Added some useful constants for conversion from GPS time to PAN time.

### Ptest Effects
None, Ptest is using its own time for now.

### Testing
`MATLAB/run_tests.m` passes.
`teensy36` tests pass.

### Constants
Changed `const.dt = int64(1e8);` to `const.dt = int64(120e6);`

Added:
```
const.INIT_GPSNS= int64(const.INITGPS_WN)*int64(1E9)*int64(7*24*60*60);
% INITGPS_WN in nanoseconds (ns)
```

### Documentation Evidence
Updated
`MATLAB/README.md`
