### PR TITLE
Added Teensy Build of PSim to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,4 +30,5 @@ jobs:
         
     - name: Teensy build
       run: |
-        python -m platformio run --verbose -e teensy35
+        python -m platformio run --verbose -e teensy35_ci
+        python -m platformio run --verbose -e teensy36_ci

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,10 +21,13 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install -r requirements.txt
         python -m platformio update
-
-    - name: C++ software tests
-      run: |
         python -m platformio platform install native
-        python -m platformio test --verbose -e github
         python -m platformio platform install teensy
+
+    - name: Desktop software tests
+      run: |
+        python -m platformio test --verbose -e github
+        
+    - name: Teensy build
+      run: |
         python -m platformio run --verbose -e teensy35

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,9 @@ jobs:
         python -m pip install -r requirements.txt
         python -m platformio update
 
-    - name: CXX software tests
+    - name: C++ software tests
       run: |
         python -m platformio platform install native
         python -m platformio test --verbose -e github
+        python -m platformio platform install teensy
+        python -m platformio run --verbose -e teensy35

--- a/platformio.ini
+++ b/platformio.ini
@@ -38,6 +38,7 @@ build_unflags =
   -fsingle-precision-constant
   -fmath-errno
 framework = arduino
+src_filter = +<*.cpp> +<*.c> +<targets/dummy_teensy.cpp>
 platform = teensy
 upload_protocol = teensy-cli
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -38,7 +38,6 @@ build_unflags =
   -fsingle-precision-constant
   -fmath-errno
 framework = arduino
-src_filter = +<*.cpp> +<*.c> +<targets/dummy_teensy.cpp>
 platform = teensy
 upload_protocol = teensy-cli
 
@@ -46,6 +45,14 @@ upload_protocol = teensy-cli
 extends = teensy
 board = teensy35
 
+[env:teensy35_ci]
+extends = env:teensy35
+src_filter = +<*.cpp> +<targets/dummy_teensy.cpp>
+
 [env:teensy36]
 extends = teensy
 board = teensy36
+
+[env:teensy36_ci]
+extends = env:teensy36
+src_filter = +<*.cpp> +<targets/dummy_teensy.cpp>

--- a/src/targets/dummy_teensy.cpp
+++ b/src/targets/dummy_teensy.cpp
@@ -1,0 +1,7 @@
+// This files purpose it to allow CI to compile with the teensy35 and/or
+// teensy36 compilers.
+
+#include <Arduino.h>
+
+void setup() { }
+void loop() { }


### PR DESCRIPTION
# Added Teensy Build of PSim to CI

### Summary of changes
- Added teensy build to CI to prevent build issues from sneaking in.
- Updated lin to fix compilation issue on teensy.

I'm also going to open up a ticket to clean up our build targets here in PSim and remove some of the duplicate macros that we have flying around.

### Ptest Effects
NA

### Testing
This is the testing.

### Constants
NA

### Documentation Evidence
NA
