### PR TITLE
Python lin and orb Wrappers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,3 +32,8 @@ jobs:
       run: |
         python -m platformio run --verbose -e teensy35_ci
         python -m platformio run --verbose -e teensy36_ci
+
+    - name: Python Wrapper tests
+      run: |
+        pip install pytest
+        pytest estimatortest/

--- a/.gitignore
+++ b/.gitignore
@@ -126,6 +126,10 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
+# cppimport stuff
+*.cppimporthash
+*.rendered.*.cpp
+
 .DS_Store
 .vscode
 .pioenvs

--- a/estimatortest/pythonwrapper/__init__.py
+++ b/estimatortest/pythonwrapper/__init__.py
@@ -1,0 +1,2 @@
+import cppimport.import_hook
+from . import pwrap

--- a/estimatortest/pythonwrapper/lin_ext.cpp
+++ b/estimatortest/pythonwrapper/lin_ext.cpp
@@ -10,6 +10,8 @@
 #include <orb/Orbit.h>
 #include <lin/core.hpp>
 #include <lin/generators.hpp>
+#include <sstream>
+
 
 namespace py = pybind11;
 
@@ -54,7 +56,9 @@ namespace py = pybind11;
             for (lin::size_t i=0; i<n; i++){ \
                 out += "\n"; \
                 for (lin::size_t j=0; j<m; j++){ \
-                    out += std::to_string(x(i,j))+","; \
+                    std::ostringstream ss; \
+                    ss << x(i,j); \
+                    out += ss.str()+","; \
                 } \
             } \
             return out; \
@@ -113,7 +117,9 @@ namespace py = pybind11;
             for (lin::size_t i=0; i<n; i++){ \
                 out += "\n"; \
                 for (lin::size_t j=0; j<m; j++){ \
-                    out += std::to_string(x(i,j))+","; \
+                    std::ostringstream ss; \
+                    ss << x(i,j); \
+                    out += ss.str()+","; \
                 } \
             } \
             return out; \
@@ -141,6 +147,52 @@ namespace py = pybind11;
  * Contains python wrappers of used lin types. 
  */ 
 void init_lin_ext(py::module &m){
-    WRAPLINMATRIX("lin_Matrix6x6d",m,double,6,6,6,6);
+    WRAPLINVECTOR("lin_Vector2f",m,float,2,2);
+    WRAPLINVECTOR("lin_Vector3f",m,float,3,3);
+    WRAPLINVECTOR("lin_Vector4f",m,float,4,4);
+    WRAPLINVECTOR("lin_Vector5f",m,float,5,5);
+    WRAPLINVECTOR("lin_Vector6f",m,float,6,6);
+    WRAPLINVECTOR("lin_Vector7f",m,float,7,7);
+    WRAPLINVECTOR("lin_Vector8f",m,float,8,8);
+    WRAPLINVECTOR("lin_Vector9f",m,float,9,9);
+    WRAPLINVECTOR("lin_Vector10f",m,float,10,10);
+    WRAPLINVECTOR("lin_Vector11f",m,float,11,11);
+    WRAPLINVECTOR("lin_Vector12f",m,float,12,12);
+
+    WRAPLINVECTOR("lin_Vector2d",m,double,2,2);
     WRAPLINVECTOR("lin_Vector3d",m,double,3,3);
+    WRAPLINVECTOR("lin_Vector4d",m,double,4,4);
+    WRAPLINVECTOR("lin_Vector5d",m,double,5,5);
+    WRAPLINVECTOR("lin_Vector6d",m,double,6,6);
+    WRAPLINVECTOR("lin_Vector7d",m,double,7,7);
+    WRAPLINVECTOR("lin_Vector8d",m,double,8,8);
+    WRAPLINVECTOR("lin_Vector9d",m,double,9,9);
+    WRAPLINVECTOR("lin_Vector10d",m,double,10,10);
+    WRAPLINVECTOR("lin_Vector11d",m,double,11,11);
+    WRAPLINVECTOR("lin_Vector12d",m,double,12,12);
+
+    WRAPLINMATRIX("lin_Matrix2x2f",m,float,2,2,2,2);
+    WRAPLINMATRIX("lin_Matrix3x3f",m,float,3,3,3,3);
+    WRAPLINMATRIX("lin_Matrix4x4f",m,float,4,4,4,4);
+    WRAPLINMATRIX("lin_Matrix5x5f",m,float,5,5,5,5);
+    WRAPLINMATRIX("lin_Matrix6x6f",m,float,6,6,6,6);
+    WRAPLINMATRIX("lin_Matrix7x7f",m,float,7,7,7,7);
+    WRAPLINMATRIX("lin_Matrix8x8f",m,float,8,8,8,8);
+    WRAPLINMATRIX("lin_Matrix9x9f",m,float,9,9,9,9);
+    WRAPLINMATRIX("lin_Matrix10x10f",m,float,10,10,10,10);
+    WRAPLINMATRIX("lin_Matrix11x11f",m,float,11,11,11,11);
+    WRAPLINMATRIX("lin_Matrix12x12f",m,float,12,12,12,12);
+
+    WRAPLINMATRIX("lin_Matrix2x2d",m,double,2,2,2,2);
+    WRAPLINMATRIX("lin_Matrix3x3d",m,double,3,3,3,3);
+    WRAPLINMATRIX("lin_Matrix4x4d",m,double,4,4,4,4);
+    WRAPLINMATRIX("lin_Matrix5x5d",m,double,5,5,5,5);
+    WRAPLINMATRIX("lin_Matrix6x6d",m,double,6,6,6,6);
+    WRAPLINMATRIX("lin_Matrix7x7d",m,double,7,7,7,7);
+    WRAPLINMATRIX("lin_Matrix8x8d",m,double,8,8,8,8);
+    WRAPLINMATRIX("lin_Matrix9x9d",m,double,9,9,9,9);
+    WRAPLINMATRIX("lin_Matrix10x10d",m,double,10,10,10,10);
+    WRAPLINMATRIX("lin_Matrix11x11d",m,double,11,11,11,11);
+    WRAPLINMATRIX("lin_Matrix12x12d",m,double,12,12,12,12);
+
 }

--- a/estimatortest/pythonwrapper/lin_ext.cpp
+++ b/estimatortest/pythonwrapper/lin_ext.cpp
@@ -1,0 +1,146 @@
+/** Contains python wrappers of used lin types. 
+ * 
+ */ 
+
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <pybind11/stl.h>
+#include <string>
+#include <stdio.h>
+#include <orb/Orbit.h>
+#include <lin/core.hpp>
+#include <lin/generators.hpp>
+
+namespace py = pybind11;
+
+/**
+ * Wrap lin Matrix.
+ * */
+#define WRAPLINMATRIX(pythontypename,module,T,R,C,MR,MC) py::class_<lin::Matrix<T, R, C, MR, MC>>(module,pythontypename,py::buffer_protocol())\
+        .def("__init__", [](lin::Matrix<T, R, C, MR, MC> &x, py::array_t<T> b) { \
+            /* Request a buffer descriptor from Python */ \
+            py::buffer_info info = b.request(); \
+            /* Some sanity checks ... */ \
+            if (info.format != py::format_descriptor<T>::format()) \
+                throw std::runtime_error("Incompatible format: expected a " #T " array!"); \
+            if (info.ndim != 2) \
+                throw std::runtime_error("Incompatible buffer dimension!"); \
+            if (info.shape[0] != (long)(x.rows())) \
+                throw std::runtime_error("Incompatible buffer shape!"); \
+            if (info.shape[1] != (long)(x.cols())) \
+                throw std::runtime_error("Incompatible buffer shape!"); \
+            lin::size_t n= x.rows(); \
+            lin::size_t m= x.cols(); \
+            for (lin::size_t i=0; i<n; i++){ \
+                for (lin::size_t j=0; j<m; j++){ \
+                    x(i,j)= *(reinterpret_cast<T*>(reinterpret_cast<char*>(info.ptr)+i*info.strides[0]+j*info.strides[1])); \
+                } \
+            } \
+        }) \
+        .def_buffer([](lin::Matrix<T, R, C, MR, MC>& x)->py::buffer_info{ \
+            return py::buffer_info( \
+                &(x(0)),                            /* Pointer to buffer */ \
+                sizeof(T),                          /* Size of one scalar */ \
+                py::format_descriptor<T>::format(), /* Python struct-style format descriptor */ \
+                2,                                  /* Number of dimensions */ \
+                {x.rows(),x.cols()},                /* Buffer dimensions */ \
+                { MC*sizeof(T),sizeof(T)}           /* Strides (in bytes) for each index */ \
+            ); \
+        }) \
+        .def("__repr__",[](const lin::Matrix<T, R, C, MR, MC>& x){ \
+            std::string out=pythontypename; \
+            lin::size_t n= x.rows(); \
+            lin::size_t m= x.cols(); \
+            for (lin::size_t i=0; i<n; i++){ \
+                out += "\n"; \
+                for (lin::size_t j=0; j<m; j++){ \
+                    out += std::to_string(x(i,j))+","; \
+                } \
+            } \
+            return out; \
+        }) \
+        .def("__call__",[](const lin::Matrix<T, R, C, MR, MC>& x, lin::size_t i, lin::size_t j){return x(i,j);}) \
+        .def("__call__",[](const lin::Matrix<T, R, C, MR, MC>& x, lin::size_t i){return x(i);}) \
+        .def(py::pickle(\
+            [](const lin::Matrix<T, R, C, MR, MC>& p) { /* __getstate__ */ \
+                /* Return a tuple that fully encodes the state of the object */   \
+                std::array<T,MR*MC> a; \
+                lin::Matrix<T, R, C, MR, MC> c= p; \
+                memcpy(&a,&(c(0)),MR*MC*sizeof(T)); \
+                return a; \
+                }, \
+            [](std::array<T,MR*MC> t) { /* __setstate__ */ \
+                /* Create a new C++ instance */ \
+                lin::Matrix<T, R, C, MR, MC> p; \
+                memcpy(&(p(0)),&t,MR*MC*sizeof(T)); \
+                return p; \
+            } \
+        ))\
+
+/**
+ * Wrap lin Vector.
+ * */
+#define WRAPLINVECTOR(pythontypename,module,T,N,MN) py::class_<lin::Vector<T, N, MN>>(module,pythontypename,py::buffer_protocol())\
+        .def("__init__", [](lin::Vector<T, N, MN> &x, py::array_t<T> b) { \
+            /* Request a buffer descriptor from Python */ \
+            py::buffer_info info = b.request(); \
+            /* Some sanity checks ... */ \
+            if (info.format != py::format_descriptor<T>::format()) \
+                throw std::runtime_error("Incompatible format: expected a " #T " array!"); \
+            if (info.ndim != 1) \
+                throw std::runtime_error("Incompatible buffer dimension!"); \
+            if (info.shape[0] != (long)(x.size())) \
+                throw std::runtime_error("Incompatible buffer shape!"); \
+            lin::size_t n= x.size(); \
+            for (lin::size_t i=0; i<n; i++){ \
+                x(i)= *(reinterpret_cast<T*>(reinterpret_cast<char*>(info.ptr)+i*info.strides[0])); \
+            } \
+        }) \
+        .def_buffer([](lin::Vector<T, N, MN>& x)->py::buffer_info{ \
+            return py::buffer_info( \
+                &(x(0)),                            /* Pointer to buffer */ \
+                sizeof(T),                          /* Size of one scalar */ \
+                py::format_descriptor<T>::format(), /* Python struct-style format descriptor */ \
+                1,                                  /* Number of dimensions */ \
+                {x.size()},                         /* Buffer dimensions */ \
+                {sizeof(T)}                         /* Strides (in bytes) for each index */ \
+            ); \
+        }) \
+        .def("__repr__",[](const lin::Vector<T, N, MN>& x){ \
+            std::string out=pythontypename; \
+            lin::size_t n= x.rows(); \
+            lin::size_t m= x.cols(); \
+            for (lin::size_t i=0; i<n; i++){ \
+                out += "\n"; \
+                for (lin::size_t j=0; j<m; j++){ \
+                    out += std::to_string(x(i,j))+","; \
+                } \
+            } \
+            return out; \
+        }) \
+        .def("__call__",[](const lin::Vector<T, N, MN>& x, lin::size_t i, lin::size_t j){return x(i,j);}) \
+        .def("__call__",[](const lin::Vector<T, N, MN>& x, lin::size_t i){return x(i);}) \
+        .def(py::pickle(\
+            [](const lin::Vector<T, N, MN> &p) { /* __getstate__ */ \
+                /* Return a tuple that fully encodes the state of the object */   \
+                std::array<T,MN> a; \
+                lin::Vector<T, N, MN> c= p; \
+                memcpy(&a,&(c(0)),MN*sizeof(T)); \
+                return a; \
+                }, \
+            [](std::array<T,MN> t) { /* __setstate__ */ \
+                /* Create a new C++ instance */ \
+                lin::Vector<T, N, MN> p; \
+                memcpy(&(p(0)),&t,MN*sizeof(T)); \
+                return p; \
+            } \
+        ))\
+
+
+/** 
+ * Contains python wrappers of used lin types. 
+ */ 
+void init_lin_ext(py::module &m){
+    WRAPLINMATRIX("lin_Matrix6x6d",m,double,6,6,6,6);
+    WRAPLINVECTOR("lin_Vector3d",m,double,3,3);
+}

--- a/estimatortest/pythonwrapper/orb_ext.cpp
+++ b/estimatortest/pythonwrapper/orb_ext.cpp
@@ -1,0 +1,73 @@
+/** Contains python wrappers of orb. 
+ * 
+ */ 
+
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <string>
+#include <stdio.h>
+#include <orb/Orbit.h>
+#include <lin/core.hpp>
+#include <lin/generators.hpp>
+
+namespace py = pybind11;
+
+/** 
+ * Contains python wrappers of orb. 
+ */ 
+void init_orb_ext(py::module &m){
+        py::class_<orb::Orbit>(m,"orb_Orbit")
+        .def(py::init<const int64_t&,const lin::Vector3d&,const lin::Vector3d&>())
+        .def(py::init<>())
+        .def("nsgpstime", &orb::Orbit::nsgpstime)
+        .def("recef", &orb::Orbit::recef)
+        .def("vecef", &orb::Orbit::vecef)
+        .def("valid", &orb::Orbit::valid)
+        .def("__repr__",[](const orb::Orbit& x){
+            return 
+                "Orbit\n"
+                "gps time: "+std::to_string(x.nsgpstime())+" ns\n"+
+                "position ECEF: "+std::to_string(x.recef()(0))+", "+std::to_string(x.recef()(1))+", "+std::to_string(x.recef()(2))+" m\n"+
+                "velocity ECEF: "+std::to_string(x.vecef()(0))+", "+std::to_string(x.vecef()(1))+", "+std::to_string(x.vecef()(2))+" m/s";
+        })
+        .def("applydeltav", &orb::Orbit::applydeltav)
+        .def("specificenergy", &orb::Orbit::specificenergy)
+        .def("shortupdate", [](orb::Orbit& x, int32_t dt_ns, const lin::Vector3d &earth_rate_ecef){
+            double specificenergy; 
+            lin::Matrix< double, 6, 6 > jac;
+            x.shortupdate(dt_ns,earth_rate_ecef,specificenergy,jac);
+            return std::make_tuple(specificenergy, jac);
+        })
+        .def("update", [](orb::Orbit& x, const int64_t &end_gps_time_ns, const lin::Vector3d &earth_rate_ecef){
+            x.startpropagating(end_gps_time_ns,earth_rate_ecef);
+            x.finishpropagating();
+        })
+        .def_static("calc_geograv", [](const lin::Vector3d &r_ecef){
+            double pot;
+            lin::Vector3d g_ecef;
+            orb::Orbit::calc_geograv (r_ecef, g_ecef, pot);
+            return std::make_tuple(g_ecef, pot);
+        })
+        .def(py::pickle(
+            [](const orb::Orbit &p) { // __getstate__
+                /* Return a tuple that fully encodes the state of the object */
+                return py::make_tuple(p.nsgpstime(),p.recef()(0),p.recef()(1),p.recef()(2),p.vecef()(0),p.vecef()(1),p.vecef()(2));
+                },
+            [](py::tuple t) { // __setstate__
+                if (t.size() != 7)
+                    throw std::runtime_error("Invalid state!");
+                /* Create a new C++ instance */
+                int64_t time= t[0].cast<int64_t>();
+                double r0 = t[1].cast<double>();
+                double r1 = t[2].cast<double>();
+                double r2 = t[3].cast<double>();
+                double v0 = t[4].cast<double>();
+                double v1 = t[5].cast<double>();
+                double v2 = t[6].cast<double>();
+                orb::Orbit p(time,{r0,r1,r2},{v0,v1,v2});
+                return p;
+            }
+        ))
+
+        ;
+}

--- a/estimatortest/pythonwrapper/pwrap.cpp
+++ b/estimatortest/pythonwrapper/pwrap.cpp
@@ -1,0 +1,63 @@
+/*cppimport
+<%
+setup_pybind11(cfg)
+from pathlib import Path
+import pybind11
+mypath=Path(filepath)
+psimpath= mypath.parent.parent.parent
+#flightsoftwarepath= psimpath.parent/'FlightSoftware'
+# 'dependencies' controls what get checked for changes before recompile
+cfg['dependencies'] = [str(p) for p in (psimpath/'src').rglob('*') if p.is_file()]
+cfg['dependencies'] += [str(p) for p in (psimpath/'lib').rglob('*') if p.is_file()]
+cfg['dependencies'] += [str(p) for p in (psimpath/'include').rglob('*') if p.is_file()]
+#cfg['dependencies'] += [str(p) for p in (flightsoftwarepath/'src').rglob('*') if p.is_file()]
+#cfg['dependencies'] += [str(p) for p in (flightsoftwarepath/'lib').rglob('*') if p.is_file()]
+
+cfg['sources'] = ['lin_ext.cpp', 'orb_ext.cpp']
+cfg['sources'] += [str(p) for p in (psimpath/'src').rglob('*.cpp') if (p.is_file() and p.parent.name!='targets')]
+#cfg['sources'] += [str(p) for p in (flightsoftwarepath/'src/fsw').rglob('*.cpp') if (p.is_file() and p.parent.name!='targets')]
+#cfg['sources'] += [str(p) for p in (flightsoftwarepath/'src/common').rglob('*.cpp') if (p.is_file() and p.parent.name!='targets')]
+
+cfg['include_dirs'] = [str(psimpath/'include'), 
+                       str(psimpath/'lib/lin/include')]
+cfg['include_dirs'] += [pybind11.get_include(), pybind11.get_include(True)]
+#cfg['include_dirs'] += [str(flightsoftwarepath/'src'), 
+#                         str(flightsoftwarepath/'lib/common/libsbp/include'),
+#                         str(flightsoftwarepath/'lib/common/ArduinoJson/src'),
+#                         str(flightsoftwarepath/'lib/common/concurrentqueue')]
+
+# compiler flags
+cfg['compiler_args']= ['-std=c++14']
+cfg['compiler_args']+= ['-DDESKTOP','-DFUNCTIONAL_TEST','-DUNIT_TEST']
+
+#platform dependent compiler flags
+from sys import platform
+if platform == "linux" or platform == "linux2":
+    # linux
+    cfg['compiler_args'] += ['-fvisibility=hidden']
+elif platform == "darwin":
+    # OS X
+    cfg['compiler_args'] += ['-mmacosx-version-min=10.9','-fvisibility=hidden']
+elif platform == "win32":
+    pass
+    # Windows...
+%>
+*/
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <string>
+#include <stdio.h>
+#include <lin/core.hpp>
+#include <lin/generators.hpp>
+
+namespace py = pybind11;
+
+void init_lin_ext(py::module &);
+void init_orb_ext(py::module &);
+//void init_common_ext(py::module &);
+
+PYBIND11_MODULE(pwrap, m) {
+    init_lin_ext(m);
+    init_orb_ext(m);
+    //init_common_ext(m);
+}

--- a/estimatortest/pythonwrapper/pwrap.cpp
+++ b/estimatortest/pythonwrapper/pwrap.cpp
@@ -10,6 +10,8 @@ psimpath= mypath.parent.parent.parent
 cfg['dependencies'] = [str(p) for p in (psimpath/'src').rglob('*') if p.is_file()]
 cfg['dependencies'] += [str(p) for p in (psimpath/'lib').rglob('*') if p.is_file()]
 cfg['dependencies'] += [str(p) for p in (psimpath/'include').rglob('*') if p.is_file()]
+cfg['dependencies'] += [str(mypath.parent/'lin_ext.cpp')]
+cfg['dependencies'] += [str(mypath.parent/'orb_ext.cpp')]
 #cfg['dependencies'] += [str(p) for p in (flightsoftwarepath/'src').rglob('*') if p.is_file()]
 #cfg['dependencies'] += [str(p) for p in (flightsoftwarepath/'lib').rglob('*') if p.is_file()]
 

--- a/estimatortest/pythonwrapper/test_compilation.py
+++ b/estimatortest/pythonwrapper/test_compilation.py
@@ -1,0 +1,11 @@
+import cppimport
+
+def test_comp():
+    from pythonwrapper import pwrap
+    print(pwrap.orb_Orbit())
+
+if __name__ == "__main__":
+    cppimport.set_quiet(False)
+    cppimport.force_rebuild(True)
+    pwrap= cppimport.imp("pwrap")
+    print(pwrap.orb_Orbit())

--- a/estimatortest/pythonwrapper/test_lin.py
+++ b/estimatortest/pythonwrapper/test_lin.py
@@ -129,8 +129,6 @@ def testmatix():
     assert np.all(np.array(b)==np.array([[1,2],[3,4]],dtype='f8'))
 
 
-
-
 if __name__ == "__main__":
     pwrap= cppimport.imp("pwrap")
     testvectors()

--- a/estimatortest/pythonwrapper/test_lin.py
+++ b/estimatortest/pythonwrapper/test_lin.py
@@ -1,9 +1,11 @@
 import cppimport
 import numpy as np
 import copy
+if __name__ != "__main__":
+    from pythonwrapper import pwrap
+    #This is because pytest is weird with setting the path
 
 def test_lin():
-    from pythonwrapper import pwrap
     testvectors()
     testmatix()
 

--- a/estimatortest/pythonwrapper/test_lin.py
+++ b/estimatortest/pythonwrapper/test_lin.py
@@ -1,0 +1,136 @@
+import cppimport
+import numpy as np
+import copy
+
+def test_lin():
+    from pythonwrapper import pwrap
+    testvectors()
+    testmatix()
+
+def testvectors():
+    # lin_Vectors can be made from regular lists
+    x= pwrap.lin_Vector3f([1.0,2.0,1.0E-9])
+    x= pwrap.lin_Vector3f([1,2.0,1.0E-9])
+    x= pwrap.lin_Vector3d([1.0,2.0,1.0E-9])
+    x= pwrap.lin_Vector3d([1,2.0,1.0E-9])
+
+    # lin_Vectors can be made from numpy arrays, types are auto casted to f4 or f8
+    x= pwrap.lin_Vector3f(np.array([1.0,2.0,1.0E-9]))
+    x= pwrap.lin_Vector3d(np.array([1.0,2.0,1.0E-9]))
+    x= pwrap.lin_Vector3d(np.array([1,2,3]))
+
+    # lin_Vectors can be made from other lin_Vectors types are auto casted to f4 or f8
+    x= pwrap.lin_Vector3f(pwrap.lin_Vector3f(np.array([1.0,2.0,1.0E-9])))
+    x= pwrap.lin_Vector3f(pwrap.lin_Vector3d(np.array([1.0,2.0,1.0E-9])))
+    x= pwrap.lin_Vector3d(pwrap.lin_Vector3f(np.array([1,2,3])))
+    x= pwrap.lin_Vector3d(pwrap.lin_Vector3d(np.array([1,2,3])))
+
+    # lin_Vectors can be cast back into numpy arrays
+    a= np.array([1.0,2.0,1.0E-9],dtype='f4')
+    x= np.array(pwrap.lin_Vector3f(a))
+    assert np.all(a==x)
+
+    a= np.array([1.0,2.0,1.0E-9],dtype='f8')
+    x= np.array(pwrap.lin_Vector3d(a))
+    assert np.all(a==x)
+
+    # lin_Vectors can be cast into numpy arrays without copying
+    # changing elements in the numpy array will also change the lin_Vector
+    a= pwrap.lin_Vector3f(np.array([1.0,2.0,1.0E-9],dtype='f4'))
+    x= np.array(a,copy=False)
+    x[0]=5
+    assert np.all(np.array(a)==x)
+
+    a= pwrap.lin_Vector3d(np.array([1.0,2.0,1.0E-9],dtype='f8'))
+    x= np.array(a,copy=False)
+    x[0]=5
+    assert np.all(np.array(a)==x)
+
+    # lin_Vectors are references
+    a= pwrap.lin_Vector3f(np.array([1.0,2.0,1.0E-9],dtype='f4'))
+    b= a #b is just a reference to a, not a copy
+    x= np.array(a,copy=False)
+    x[0]=5 #changes to x also change a and b
+    assert np.all(np.array(a)==x)
+    assert np.all(np.array(b)==x)
+
+    # lin_Vectors can be deep copied
+    a= pwrap.lin_Vector3f(np.array([1.0,2.0,1.0E-9],dtype='f4'))
+    b= copy.deepcopy(a) #b is an independent copy of a
+    x= np.array(a,copy=False)
+    x[0]=5
+    assert np.all(np.array(a)==x)
+    assert np.all(np.array(b)==np.array([1.0,2.0,1.0E-9],dtype='f4'))
+
+    a= pwrap.lin_Vector3f(np.array([1.0,2.0,1.0E-9],dtype='f4'))
+    b= pwrap.lin_Vector3f(a) #b is an independent copy of a
+    x= np.array(a,copy=False)
+    x[0]=5
+    assert np.all(np.array(a)==x)
+    assert np.all(np.array(b)==np.array([1.0,2.0,1.0E-9],dtype='f4'))
+
+def testmatix():
+    # lin_Matix can be made from regular lists
+    x= pwrap.lin_Matrix2x2f([[1,2],[3,4]])
+    x= pwrap.lin_Matrix2x2d([[1,2],[3,4]])
+
+    # lin_Matix can be made from numpy arrays, types are auto casted to f4 or f8
+    x= pwrap.lin_Matrix2x2f(np.array([[1,2],[3,4]]))
+    x= pwrap.lin_Matrix2x2d(np.array([[1,2],[3,4]]))
+
+    # lin_Matix can be made from other lin_Matix types are auto casted to f4 or f8
+    x= pwrap.lin_Matrix2x2f(np.array([[1,2],[3,4]]))
+    x= pwrap.lin_Matrix2x2d(np.array([[1,2],[3,4]]))
+
+    # lin_Matix can be cast back into numpy arrays
+    a= np.array([[1,2],[3,4]],dtype='f4')
+    x= np.array(pwrap.lin_Matrix2x2f(a))
+    assert np.all(a==x)
+
+    a= np.array([[1,2],[3,4]],dtype='f8')
+    x= np.array(pwrap.lin_Matrix2x2d(a))
+    assert np.all(a==x)
+
+    # lin_Matix can be cast into numpy arrays without copying
+    # changing elements in the numpy array will also change the lin_Vector
+    a= pwrap.lin_Matrix2x2f(np.array([[1,2],[3,4]]))
+    x= np.array(a,copy=False)
+    x[0,0]=5
+    assert np.all(np.array(a)==x)
+
+    a= pwrap.lin_Matrix2x2d(np.array([[1,2],[3,4]]))
+    x= np.array(a,copy=False)
+    x[0,0]=5
+    assert np.all(np.array(a)==x)
+
+    # lin_Matix are references
+    a= pwrap.lin_Matrix2x2d(np.array([[1,2],[3,4]]))
+    b= a #b is just a reference to a, not a copy
+    x= np.array(a,copy=False)
+    x[0,0]=5 #changes to x also change a and b
+    assert np.all(np.array(a)==x)
+    assert np.all(np.array(b)==x)
+
+    # lin_Matix can be deep copied
+    a= pwrap.lin_Matrix2x2d(np.array([[1,2],[3,4]]))
+    b= copy.deepcopy(a) #b is an independent copy of a
+    x= np.array(a,copy=False)
+    x[0,0]=5
+    assert np.all(np.array(a)==x)
+    assert np.all(np.array(b)==np.array([[1,2],[3,4]],dtype='f8'))
+
+    a= pwrap.lin_Matrix2x2d(np.array([[1,2],[3,4]]))
+    b= pwrap.lin_Matrix2x2d(a) #b is an independent copy of a
+    x= np.array(a,copy=False)
+    x[0,0]=5
+    assert np.all(np.array(a)==x)
+    assert np.all(np.array(b)==np.array([[1,2],[3,4]],dtype='f8'))
+
+
+
+
+if __name__ == "__main__":
+    pwrap= cppimport.imp("pwrap")
+    testvectors()
+    testmatix()
+

--- a/estimatortest/pythonwrapper/test_orb.py
+++ b/estimatortest/pythonwrapper/test_orb.py
@@ -1,0 +1,64 @@
+import cppimport
+import numpy as np
+import copy
+
+if __name__ != "__main__":
+    from pythonwrapper import pwrap
+    #This is because pytest is weird with setting the path
+
+def test_orb():
+    #Create invalid Orbits
+    x= pwrap.orb_Orbit()
+    assert x.valid()==False
+
+    #Create valid Orbits
+    earth_rate_ecef= pwrap.lin_Vector3d([0.000000707063506E-4,-0.000001060595259E-4,0.729211585530000E-4])
+    t0= 2045*7*24*60*60*1000*1000*1000
+    r0= pwrap.lin_Vector3d([-6522019.833240811, 2067829.846415895, 776905.9724453629])
+    v0= pwrap.lin_Vector3d([941.0211143841228, 85.66662333729801, 7552.870253470936])
+    y= pwrap.orb_Orbit(t0,r0,v0)
+    assert y.valid()==True
+
+    #Getters
+    assert y.nsgpstime()==t0
+    assert x.nsgpstime()==0
+    assert np.all(np.array(y.recef())==np.array(r0))
+    assert np.all(np.array(y.vecef())==np.array(v0))
+    assert np.all(np.isnan(np.array(x.recef())))
+    assert np.all(np.isnan(np.array(x.vecef())))
+
+    #applydeltav
+    y.applydeltav(pwrap.lin_Vector3d([1, 0, 0]))
+    assert np.all(np.array(y.recef())==np.array(r0)+np.array([1, 0, 0],dtype='f8'))
+
+    #specificenergy
+    e= y.specificenergy(earth_rate_ecef)
+    assert type(e) is float
+
+    #shortupdate returns a tuple of specific energy and the jacobian.
+    e1,jac = y.shortupdate(1000,earth_rate_ecef)
+    assert np.abs(e-e1) < 1E-5
+    assert type(e1) is float
+    assert type(jac) is pwrap.lin_Matrix6x6d
+
+    #update is used for longer updates
+    y.update(1000_000_000_000,earth_rate_ecef)
+    assert y.valid()
+
+    #calc_geograv is a static member returns a tuple of acceleration and potential
+    g,p= pwrap.orb_Orbit.calc_geograv(r0)
+
+    #orb_Orbit is deepcopy able
+    y= pwrap.orb_Orbit(t0,r0,v0)
+    z= copy.deepcopy(y)
+    y.update(1_000_000_000, earth_rate_ecef)
+    assert z.valid()
+    assert z.nsgpstime()==t0
+    assert np.all(np.array(z.recef())==np.array(r0))
+    assert np.all(np.array(z.vecef())==np.array(v0))
+
+
+if __name__ == "__main__":
+    pwrap= cppimport.imp("pwrap")
+    test_orb()
+

--- a/estimatortest/pythonwrapper/test_orb.py
+++ b/estimatortest/pythonwrapper/test_orb.py
@@ -42,7 +42,7 @@ def test_orb():
     assert type(jac) is pwrap.lin_Matrix6x6d
 
     #update is used for longer updates
-    y.update(1000_000_000_000,earth_rate_ecef)
+    y.update(t0+1000_000_000_000,earth_rate_ecef)
     assert y.valid()
 
     #calc_geograv is a static member returns a tuple of acceleration and potential
@@ -51,7 +51,7 @@ def test_orb():
     #orb_Orbit is deepcopy able
     y= pwrap.orb_Orbit(t0,r0,v0)
     z= copy.deepcopy(y)
-    y.update(1_000_000_000, earth_rate_ecef)
+    y.update(t0+1_000_000_000, earth_rate_ecef)
     assert z.valid()
     assert z.nsgpstime()==t0
     assert np.all(np.array(z.recef())==np.array(r0))

--- a/estimatortest/pythonwrapper/test_orb.py
+++ b/estimatortest/pythonwrapper/test_orb.py
@@ -29,7 +29,7 @@ def test_orb():
 
     #applydeltav
     y.applydeltav(pwrap.lin_Vector3d([1, 0, 0]))
-    assert np.all(np.array(y.recef())==np.array(r0)+np.array([1, 0, 0],dtype='f8'))
+    assert np.all(np.array(y.vecef())==np.array(v0)+np.array([1, 0, 0],dtype='f8'))
 
     #specificenergy
     e= y.specificenergy(earth_rate_ecef)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,10 @@
 argparse
 platformio
 pylint
+numpy
+matplotlib
+cppimport
+h5py
+dulwich
+ipykernel
+notebook


### PR DESCRIPTION
# Python lin and orb Wrappers

Fixes #215 

### Python Wrappers
There are python wrappers for some C++ types. I am using [pybind11](https://pybind11.readthedocs.io/en/stable/intro.html) which has great documentation and many examples. pybind11 is just a header only library that makes it easy to write python extensions, https://thomasnyberg.com/what_are_extension_modules.html . 

The C++ sources need to be compiled as a shared library to be imported by python. 
I am using [cppimport](https://github.com/tbenthompson/cppimport) to do this automatically on import but it is theoretically possible to compile using cmake, pio, pip ... 

To test the compilation run `python estimatortest/pythonwrapper/test_compilation.py` Which should print a bunch of compiler errors if there is a mistake.

`psim/estimatortest/pwrap.cpp` Is the main module file.

The giant comment at the top is used in a python script that sets the compiler configuration.
`cfg['dependencies']` is a list of filenames that are checked for changes to see if recompiling is needed.
`cfg['sources']` are the sources to compile.
`cfg['include_dirs']` are the include directories.
`cfg['compiler_args']` are the compiler args, I also made a section for platform specific compiler args because my mac needed `'-mmacosx-version-min=10.9'` to compile.

#### orb wrappers
`psim/estimatortest/orb_ext.cpp` Has the `orb` wrappers.

For now `orb::Orbit` as python type `orb_Orbit` is mostly wrapped.

#### lin wrappers
`psim/estimatortest/lin_ext.cpp` Has the `lin` wrappers.

Most of this file is from https://pybind11.readthedocs.io/en/stable/advanced/pycpp/numpy.html examples.

Because `lin` uses templates, each type that you want to use in python must be specifically wrapped. For example, right now in `lin_ext.cpp` I have:
```
    WRAPLINMATRIX("lin_Matrix6x6d",m,double,6,6,6,6);
    WRAPLINVECTOR("lin_Vector3d",m,double,3,3);
```

These create python types named `lin_Matrix6x6d` and `lin_Vector3d` 
for C++ types `lin::Matrix<double, 6, 6, 6, 6>` and  `lin::Vector<double, 3, 3>`.
These are compatible with numpy arrays, so numpy.array(lin_Vector3d([1.0,2.0,3.0])) will work.
The wrapper doesn't wrap all of the `lin` features, so it's usually best to always convert the lin types into numpy arrays if you want to do math with them in python.

If you need other `lin` types in python make sure to wrap them in this file using the macros.

### Testing
I am using pytest to test the wrappers in CI.
