### PR TITLE
Bazel build for psim

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+build --cxxopt=-std=c++14

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -11,10 +11,6 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: 'recursive'
-    - uses: actions/setup-python@v1
-      with:
-        python-version: '3.7'
-        architecture: 'x64'
 
     - name: Install dependencies
       run: |
@@ -23,4 +19,3 @@ jobs:
     - name: Build and Test with Bazel
       run: |
         bazel build :psim
-        

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -1,0 +1,26 @@
+name: PSim Bazel Builds
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: 'recursive'
+    - uses: actions/setup-python@v1
+      with:
+        python-version: '3.7'
+        architecture: 'x64'
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get install bazel
+
+    - name: Build and Test with Bazel
+      run: |
+        bazel build :psim
+        

--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,10 @@ geograv/build/*
 MATLAB/psim.html
 tmp/
 .idea/
+
+# Bazel
+bazel-bin
+bazel-out
+bazel-psim
+bazel-testlogs
+bazel-genfiles

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,11 @@
+cc_library(
+    name = "psim",
+    srcs = glob(["src/**/*.cpp", "src/**/*.inl", "src/**/*.hpp", "include/**/*.inl"], exclude=["src/targets/*.cpp"]),
+    hdrs = glob(["include/**/*.hpp", "include/**/*.h"]),
+    copts = ["-Iinclude -Isrc"],
+    linkstatic = True,
+    visibility = ["//visibility:public"],
+    deps = [
+        "@lin//:lin",
+    ]
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,21 @@
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+lin_build = """
+cc_library(
+    name = "lin",
+    srcs = glob(["src/**/*.cpp", "include/**/*.inl"]),
+    hdrs = glob(["include/**/*.hpp"]),
+    includes = ["include"],
+    linkstatic = True,
+    visibility = ["//visibility:public"]
+)
+"""
+
+new_git_repository(
+    name = "lin",
+    init_submodules = True,
+    remote = "https://github.com/pathfinder-for-autonomous-navigation/lin",
+    commit = "f8fafaa5a29190663bc313a0b835201749b876b8",
+    build_file_content = lin_build
+)


### PR DESCRIPTION
### Summary of changes
- Builds `:psim` as a Bazel c++ library.
### Testing
See the Github Actions file that builds Bazel. It works!
