### PR TITLE
Dual Orbit Simulation

### DIFF
--- a/include/psim/core/simulation.hpp
+++ b/include/psim/core/simulation.hpp
@@ -52,7 +52,8 @@ class Simulation : public State {
    */
   std::unique_ptr<Model> _model;
 
-  /** @brief Private constructor employeed by the factory function.
+ protected:
+  /** @brief Private constructor employed by the factory function.
    */
   Simulation(std::unique_ptr<Model> &&model);
 

--- a/include/psim/simulations/dual_orbit.hpp
+++ b/include/psim/simulations/dual_orbit.hpp
@@ -22,32 +22,28 @@
 // SOFTWARE.
 //
 
-/** @file psim/simulation/single_orbit.cpp
+/** @file psim/simulation/dual_orbit.hpp
  *  @author Kyle Krol
  */
 
-#include <psim/simulations/single_orbit.hpp>
+#ifndef PSIM_SIMULATIONS_DUAL_ORBIT_HPP_
+#define PSIM_SIMULATIONS_DUAL_ORBIT_HPP_
 
-#include <psim/truth/earth.hpp>
-#include <psim/truth/environment.hpp>
-#include <psim/truth/orbit.hpp>
-#include <psim/truth/time.hpp>
-#include <psim/truth/transform_position.hpp>
-#include <psim/truth/transform_velocity.hpp>
+#include <psim/core/configuration.hpp>
+#include <psim/core/model_list.hpp>
 
 namespace psim {
 
-SingleOrbitGnc::SingleOrbitGnc(Configuration const &config) {
-  // Time and Earth ephemeris
-  add<Time>(config, "truth");
-  add<EarthGnc>(config, "truth");
-  // Orbital dynamics
-  add<OrbitGncEci>(config, "truth", "leader");
-  add<TransformPositionEci>(config, "truth", "truth.leader.orbit.r");
-  add<TransformVelocityEci>(config, "truth", "leader", "truth.leader.orbit.v");
-  // Environmental models
-  add<EnvironmentGnc>(config, "truth", "leader");
-  add<TransformPositionEcef>(config, "truth", "truth.leader.environment.b");
-  add<TransformPositionEci>(config, "truth", "truth.leader.environment.s");
-}
+/** @brief Models orbital dynamics for two satellites. All models are backed by
+ *         flight software's GNC implementations if possible.
+ */
+class DualOrbitGnc : public ModelList {
+ public:
+  DualOrbitGnc() = delete;
+  virtual ~DualOrbitGnc() = default;
+
+  DualOrbitGnc(Configuration const &config);
+};
 }  // namespace psim
+
+#endif

--- a/include/psim/truth/satellite_orbit.hpp
+++ b/include/psim/truth/satellite_orbit.hpp
@@ -22,24 +22,31 @@
 // SOFTWARE.
 //
 
-/** @file psim/simulation/single_orbit.cpp
+/** @file psim/truth/satellite_orbit.hpp
  *  @author Kyle Krol
  */
 
-#include <psim/simulations/single_orbit.hpp>
+#ifndef PSIM_TRUTH_SATELLITE_ORBIT_HPP_
+#define PSIM_TRUTH_SATELLITE_ORBIT_HPP_
 
-#include <psim/truth/earth.hpp>
-#include <psim/truth/satellite_orbit.hpp>
-#include <psim/truth/time.hpp>
+#include <psim/core/configuration.hpp>
+#include <psim/core/model_list.hpp>
 
 namespace psim {
 
-SingleOrbitGnc::SingleOrbitGnc(Configuration const &config) {
-  std::string const prefix = "truth";
-  // Time and Earth ephemeris
-  add<Time>(config, prefix);
-  add<EarthGnc>(config, prefix);
-  // Leader satellite
-  add<SatelliteOrbitGnc>(config, prefix, "leader");
-}
+/** @brief Models a single satellite computing only orbital dynamics.
+ *
+ *  This model needs to be embedded within a larger simulation that has a time
+ *  and Earth ephemeris model.
+ */
+class SatelliteOrbitGnc : public ModelList {
+ public:
+  SatelliteOrbitGnc() = delete;
+  virtual ~SatelliteOrbitGnc() = default;
+
+  SatelliteOrbitGnc(Configuration const &config, std::string const &prefix,
+      std::string const &satellite);
+};
 }  // namespace psim
+
+#endif

--- a/python/psim/__init__.py
+++ b/python/psim/__init__.py
@@ -7,6 +7,7 @@ from . import sims
 from .plugins import (
     Plugin,
 )
+
 from .simulation import (
     Simulation,
     SimulationRunner,

--- a/python/psim/_psim/simulations.cpp
+++ b/python/psim/_psim/simulations.cpp
@@ -31,6 +31,7 @@
 #include <psim/core/simulation.hpp>
 #include <psim/core/state_field.hpp>
 #include <psim/core/types.hpp>
+#include <psim/simulations/dual_orbit.hpp>
 #include <psim/simulations/single_orbit.hpp>
 
 #include <lin/core.hpp>
@@ -101,4 +102,5 @@ static void py_assign(psim::StateFieldWritableBase &field, T const &value) {
 
 void py_simulation(py::module &m) {
   PY_SIMULATION(SingleOrbitGnc);
+  PY_SIMULATION(DualOrbitGnc);
 }

--- a/python/psim/_psim/simulations.cpp
+++ b/python/psim/_psim/simulations.cpp
@@ -77,25 +77,25 @@ template <class C>
 class PySimulation : public psim::Simulation {
  public:
   PySimulation() = delete;
-  virtual PySimulation() = default;
+  virtual ~PySimulation() = default;
 
   template <typename... Ts>
-  PySimulation(Configuration const &config, Ts &&... ts)
+  PySimulation(psim::Configuration const &config, Ts &&... ts)
     : Simulation(std::make_unique<C>(config, std::forward<Ts>(ts)...)) { }
 };
 
 #define PY_SIMULATION(model) \
-    py::class_<PySimulation<model>>(m, #model) \
+    py::class_<PySimulation<psim::model>>(m, #model) \
       .def(py::init([](psim::Configuration const &config) { \
-        return new PySimulation<model>(config); \
+        return new PySimulation<psim::model>(config); \
       })) \
-      .def("__getitem__", [](psim::Simulation const &self, std::string const &name) { \
+      .def("__getitem__", [](PySimulation<psim::model> const &self, std::string const &name) { \
         auto const *ptr = self.get(name); \
         if (!ptr) \
           throw std::runtime_error("State field '" + name + "' does not exist."); \
         return py_visit(*ptr); \
       }) \
-      .def("__setitem__", [](psim::Simulation &self, std::string const &name, PyVariant const &value) { \
+      .def("__setitem__", [](PySimulation<psim::model> &self, std::string const &name, PyVariant const &value) { \
         auto *ptr = self.get_writable(name); \
         if (!ptr) \
           throw std::runtime_error("Writable state field '" + name + "' does not exist."); \
@@ -107,7 +107,7 @@ class PySimulation : public psim::Simulation {
           [&ptr](psim::Vector4 const &v) { py_assign(*ptr, v); } \
         ); \
       }) \
-      .def("step", [](psim::Simulation &self) { \
+      .def("step", [](PySimulation<psim::model> &self) { \
         self.step(); \
       })
 

--- a/python/psim/sims.py
+++ b/python/psim/sims.py
@@ -2,6 +2,6 @@
 """
 
 from _psim import (
-#    DualOrbitGnc,
+    DualOrbitGnc,
     SingleOrbitGnc,
 )

--- a/python/psim/sims.py
+++ b/python/psim/sims.py
@@ -2,6 +2,6 @@
 """
 
 from _psim import (
-    DualOrbitGnc,
+#    DualOrbitGnc,
     SingleOrbitGnc,
 )

--- a/python/psim/sims.py
+++ b/python/psim/sims.py
@@ -2,5 +2,6 @@
 """
 
 from _psim import (
+    DualOrbitGnc,
     SingleOrbitGnc,
 )

--- a/python/psim/simulation.py
+++ b/python/psim/simulation.py
@@ -1,8 +1,9 @@
 """Defines a set of classes that can be used to run a simulation.
 """
 
+from . import utilities
+
 from _psim import Configuration
-from psim import utilities
 
 import argparse
 import logging

--- a/python/psim/utilities.py
+++ b/python/psim/utilities.py
@@ -1,7 +1,7 @@
 """Random helper functions used throughout the rest of PSim.
 """
 
-from psim import sims
+from . import sims
 
 import logging
 import os

--- a/src/psim/simulations/dual_orbit.cpp
+++ b/src/psim/simulations/dual_orbit.cpp
@@ -29,32 +29,20 @@
 #include <psim/simulations/dual_orbit.hpp>
 
 #include <psim/truth/earth.hpp>
-#include <psim/truth/environment.hpp>
-#include <psim/truth/orbit.hpp>
+#include <psim/truth/satellite_orbit.hpp>
 #include <psim/truth/time.hpp>
-#include <psim/truth/transform_position.hpp>
-#include <psim/truth/transform_velocity.hpp>
 
 #include <string>
 
 namespace psim {
 
 DualOrbitGnc::DualOrbitGnc(Configuration const &config) {
-  auto const add_satellite = [this, &config](std::string const &satellite) -> void {
-    // Orbital dynamics
-    this->add<OrbitGncEci>(config, "truth", satellite);
-    this->add<TransformPositionEci>(config, "truth", "truth." + satellite + ".orbit.r");
-    this->add<TransformVelocityEci>(config, "truth", satellite, "truth." + satellite + ".orbit.v");
-    // Environmental models
-    this->add<EnvironmentGnc>(config, "truth", satellite);
-    this->add<TransformPositionEcef>(config, "truth", "truth." + satellite + ".environment.b");
-    this->add<TransformPositionEci>(config, "truth", "truth." + satellite + ".environment.s");
-  };
+  std::string const prefix = "truth";
   // Time and Earth ephemeris
-  add<Time>(config, "truth");
-  add<EarthGnc>(config, "truth");
+  add<Time>(config, prefix);
+  add<EarthGnc>(config, prefix);
   // Leader and follower satellites
-  add_satellite("leader");
-  add_satellite("follower");
+  add<SatelliteOrbitGnc>(config, prefix, "leader");
+  add<SatelliteOrbitGnc>(config, prefix, "follower");
 }
 }  // namespace psim

--- a/src/psim/truth/satellite_orbit.cpp
+++ b/src/psim/truth/satellite_orbit.cpp
@@ -22,24 +22,24 @@
 // SOFTWARE.
 //
 
-/** @file psim/simulation/single_orbit.cpp
- *  @author Kyle Krol
- */
-
-#include <psim/simulations/single_orbit.hpp>
-
-#include <psim/truth/earth.hpp>
 #include <psim/truth/satellite_orbit.hpp>
-#include <psim/truth/time.hpp>
+
+#include <psim/truth/environment.hpp>
+#include <psim/truth/orbit.hpp>
+#include <psim/truth/transform_position.hpp>
+#include <psim/truth/transform_velocity.hpp>
 
 namespace psim {
 
-SingleOrbitGnc::SingleOrbitGnc(Configuration const &config) {
-  std::string const prefix = "truth";
-  // Time and Earth ephemeris
-  add<Time>(config, prefix);
-  add<EarthGnc>(config, prefix);
-  // Leader satellite
-  add<SatelliteOrbitGnc>(config, prefix, "leader");
+SatelliteOrbitGnc::SatelliteOrbitGnc(Configuration const &config,
+    std::string const &prefix, std::string const &satellite) {
+  // Orbital dynamics
+  add<OrbitGncEci>(config, prefix, satellite);
+  add<TransformPositionEci>(config, prefix, prefix + "." + satellite + ".orbit.r");
+  add<TransformVelocityEci>(config, prefix, satellite, prefix + "." + satellite + ".orbit.v");
+  // Environmental models
+  add<EnvironmentGnc>(config, prefix, satellite);
+  add<TransformPositionEcef>(config, prefix, prefix + "." + satellite + ".environment.b");
+  add<TransformPositionEci>(config, prefix, prefix + "." + satellite + ".environment.s");
 }
 }  // namespace psim


### PR DESCRIPTION
Small PR to add a simulation where we model two satellites and their orbital mechanics. No attitude dynamics or attitude related actuators are included.

_This small set of changes steps through the infrastructure steps to create a new simulation and make it available in Python so it'd be very beneficial to look through what's going on here!_