### PR TITLE
Fix Builds on MacOS

### DIFF
--- a/test/psim/core/configuration_test.cpp
+++ b/test/psim/core/configuration_test.cpp
@@ -34,7 +34,7 @@ TEST(Configuration, TestGet) {
   auto const config = psim::Configuration::make(file);
 
   // Test a proper access
-  ASSERT_EQ(config.get("test.integer")->get<psim::Integer>(), 1);
+  ASSERT_EQ(config.get("test.integer")->template get<psim::Integer>(), 1);
 
   // Ensure a null pointer on an invalid access
   ASSERT_EQ(config.get("test.dne"), nullptr);
@@ -51,16 +51,16 @@ TEST(Configuration, TestMultiFileMake) {
   {
     psim::Integer test_integer;
 
-    test_integer = config["test.integer"].get<psim::Integer>();
+    test_integer = config["test.integer"].template get<psim::Integer>();
     ASSERT_EQ(test_integer, 1);
 
-    test_integer = config["test.i"].get<psim::Integer>();
+    test_integer = config["test.i"].template get<psim::Integer>();
     ASSERT_EQ(test_integer, -2);
 
-    test_integer = config["test.i"].get<psim::Integer>();
+    test_integer = config["test.i"].template get<psim::Integer>();
     ASSERT_EQ(test_integer, -2);
 
-    test_integer = config["test.j"].get<psim::Integer>();
+    test_integer = config["test.j"].template get<psim::Integer>();
     ASSERT_EQ(test_integer, 4);
   }
 }
@@ -73,10 +73,10 @@ TEST(Configuration, TestSingleFileMake) {
   {
     psim::Integer test_integer;
 
-    test_integer = config["test.integer"].get<psim::Integer>();
+    test_integer = config["test.integer"].template get<psim::Integer>();
     ASSERT_EQ(test_integer, 1);
 
-    test_integer = config["test.i"].get<psim::Integer>();
+    test_integer = config["test.i"].template get<psim::Integer>();
     ASSERT_EQ(test_integer, -2);
   }
 
@@ -84,7 +84,7 @@ TEST(Configuration, TestSingleFileMake) {
   {
     psim::Real test_real;
 
-    test_real = config["test.real"].get<psim::Real>();
+    test_real = config["test.real"].template get<psim::Real>();
     ASSERT_DOUBLE_EQ(test_real, -1.0);
   }
 
@@ -92,7 +92,7 @@ TEST(Configuration, TestSingleFileMake) {
   {
     psim::Vector2 test_vector;
 
-    test_vector = config["test.vector2"].get<psim::Vector2>();
+    test_vector = config["test.vector2"].template get<psim::Vector2>();
     ASSERT_DOUBLE_EQ(test_vector(0), 1.0);
     ASSERT_DOUBLE_EQ(test_vector(1), 2.0);
   }
@@ -101,7 +101,7 @@ TEST(Configuration, TestSingleFileMake) {
   {
     psim::Vector3 test_vector;
 
-    test_vector = config["test.vector3"].get<psim::Vector3>();
+    test_vector = config["test.vector3"].template get<psim::Vector3>();
     ASSERT_DOUBLE_EQ(test_vector(0),  1.0);
     ASSERT_DOUBLE_EQ(test_vector(1), -2.0);
     ASSERT_DOUBLE_EQ(test_vector(2),  3.0);
@@ -111,7 +111,7 @@ TEST(Configuration, TestSingleFileMake) {
   {
     psim::Vector4 test_vector;
 
-    test_vector = config["test.vector4"].get<psim::Vector4>();
+    test_vector = config["test.vector4"].template get<psim::Vector4>();
     ASSERT_DOUBLE_EQ(test_vector(0), 1.0);
     ASSERT_DOUBLE_EQ(test_vector(1), 2.0);
     ASSERT_DOUBLE_EQ(test_vector(2), 3.0);

--- a/test/psim/core/counter.cpp
+++ b/test/psim/core/counter.cpp
@@ -5,7 +5,8 @@
 #include "counter.hpp"
 
 Counter::Counter(psim::Configuration const &config)
-    : _dn("dn", config["dn"].get<psim::Integer>()), _n("n", config["n"].get<psim::Integer>()) { }
+    : _dn("dn", config["dn"].template get<psim::Integer>()),
+      _n("n", config["n"].template get<psim::Integer>()) { }
 
 void Counter::add_fields(psim::State &state) {
   this->psim::Model::add_fields(state);

--- a/test/psim/core/parameter_test.cpp
+++ b/test/psim/core/parameter_test.cpp
@@ -69,7 +69,7 @@ TEST(Parameter, TestGet) {
   {
     psim::ParameterBase *ptr = &param;
 
-    ASSERT_EQ(ptr->get<psim::Real>(), 2.0);
-    EXPECT_THROW(ptr->get<psim::Integer>(), std::runtime_error);
+    ASSERT_EQ(ptr->template get<psim::Real>(), 2.0);
+    EXPECT_THROW(ptr->template get<psim::Integer>(), std::runtime_error);
   }
 }

--- a/test/psim/core/simulation_test.cpp
+++ b/test/psim/core/simulation_test.cpp
@@ -15,10 +15,10 @@ TEST(Simulation, TestStep) {
   auto sim = psim::Simulation::make<Counter>(config);
 
   // Check initial conditions
-  ASSERT_EQ(sim["dn"].get<psim::Integer>(), 1);
-  ASSERT_EQ(sim["n"].get<psim::Integer>(), 0);
+  ASSERT_EQ(sim["dn"].template get<psim::Integer>(), 1);
+  ASSERT_EQ(sim["n"].template get<psim::Integer>(), 0);
 
   // Ensure step update the proper fields
   sim.step();
-  ASSERT_EQ(sim["n"].get<psim::Integer>(), 1);
+  ASSERT_EQ(sim["n"].template get<psim::Integer>(), 1);
 }

--- a/test/psim/core/state_field_test.cpp
+++ b/test/psim/core/state_field_test.cpp
@@ -18,23 +18,23 @@ TEST(StateField, TestCast) {
   {
     psim::StateFieldBase &base_field = field;
 
-    ASSERT_EQ(&(base_field.cast<psim::Real>()), &field);
-    EXPECT_THROW(base_field.cast<psim::Integer>(), std::runtime_error);
+    ASSERT_EQ(&(base_field.template cast<psim::Real>()), &field);
+    EXPECT_THROW(base_field.template cast<psim::Integer>(), std::runtime_error);
   }
 
   // Test for `StateFieldBase const`
   {
     psim::StateFieldBase const &base_field = field;
 
-    ASSERT_EQ(&(base_field.cast<psim::Real>()), &field);
-    EXPECT_THROW(base_field.cast<psim::Integer>(), std::runtime_error);
+    ASSERT_EQ(&(base_field.template cast<psim::Real>()), &field);
+    EXPECT_THROW(base_field.template cast<psim::Integer>(), std::runtime_error);
   }
 
   // Test for `StateField`
   {
     psim::StateField<psim::Real> &base_field = field;
 
-    ASSERT_EQ(&(base_field.cast<psim::Real>()), &field);
+    ASSERT_EQ(&(base_field.template cast<psim::Real>()), &field);
     // EXPECT_THROW(base_field.cast<psim::Integer>(), std::runtime_error);
     //   ^ throws a state assertion error
   }
@@ -43,7 +43,7 @@ TEST(StateField, TestCast) {
   {
     psim::StateField<psim::Real> const &base_field = field;
 
-    ASSERT_EQ(&(base_field.cast<psim::Real>()), &field);
+    ASSERT_EQ(&(base_field.template cast<psim::Real>()), &field);
     // EXPECT_THROW(base_field.cast<psim::Integer>(), std::runtime_error);
     //   ^ throws a state assertion error
   }
@@ -58,28 +58,28 @@ TEST(StateField, TestCastWritable) {
     {
       psim::StateFieldBase &base_field = field;
 
-      EXPECT_THROW(base_field.cast_writable<psim::Real>(), std::runtime_error);
+      EXPECT_THROW(base_field.template cast_writable<psim::Real>(), std::runtime_error);
     }
 
     // Test for `StateFieldBase const`
     {
       psim::StateFieldBase const &base_field = field;
 
-      EXPECT_THROW(base_field.cast_writable<psim::Real>(), std::runtime_error);
+      EXPECT_THROW(base_field.template cast_writable<psim::Real>(), std::runtime_error);
     }
 
     // Test for `StateField`
     {
       psim::StateField<psim::Real> *field_ptr = &field;
 
-      EXPECT_THROW(field_ptr->cast_writable<psim::Real>(), std::runtime_error);
+      EXPECT_THROW(field_ptr->template cast_writable<psim::Real>(), std::runtime_error);
     }
 
     // Test for `StateField const`
     {
       psim::StateField<psim::Real> const &base_field = field;
 
-      EXPECT_THROW(base_field.cast_writable<psim::Real>(), std::runtime_error);
+      EXPECT_THROW(base_field.template cast_writable<psim::Real>(), std::runtime_error);
     }
   }
 
@@ -99,15 +99,15 @@ TEST(StateField, TestCastWritable) {
     {
       psim::StateFieldBase const &base_field = field;
 
-      ASSERT_EQ(&(base_field.cast<psim::Real>()), &field);
-      EXPECT_THROW(base_field.cast<psim::Integer>(), std::runtime_error);
+      ASSERT_EQ(&(base_field.template cast<psim::Real>()), &field);
+      EXPECT_THROW(base_field.template cast<psim::Integer>(), std::runtime_error);
     }
 
     // Test for `StateField`
     {
       psim::StateField<psim::Real> &base_field = field;
 
-      ASSERT_EQ(&(base_field.cast<psim::Real>()), &field);
+      ASSERT_EQ(&(base_field.template cast<psim::Real>()), &field);
       // EXPECT_THROW(base_field.cast<psim::Integer>(), std::runtime_error);
       //   ^ throws a state assertion error
     }
@@ -130,23 +130,23 @@ TEST(StateField, TestGet) {
   {
     psim::StateFieldBase &base_field = field;
 
-    ASSERT_EQ(base_field.get<psim::Real>(), 2.0);
-    EXPECT_THROW(base_field.get<psim::Integer>(), std::runtime_error);
+    ASSERT_EQ(base_field.template get<psim::Real>(), 2.0);
+    EXPECT_THROW(base_field.template get<psim::Integer>(), std::runtime_error);
   }
 
   // Test for `StateFieldBase const`
   {
     psim::StateFieldBase const &base_field = field;
 
-    ASSERT_EQ(base_field.get<psim::Real>(), 2.0);
-    EXPECT_THROW(base_field.get<psim::Integer>(), std::runtime_error);
+    ASSERT_EQ(base_field.template get<psim::Real>(), 2.0);
+    EXPECT_THROW(base_field.template get<psim::Integer>(), std::runtime_error);
   }
 
   // Test for `StateField`
   {
     psim::StateField<psim::Real> &base_field = field;
 
-    ASSERT_EQ(base_field.get<psim::Real>(), 2.0);
+    ASSERT_EQ(base_field.template get<psim::Real>(), 2.0);
     // EXPECT_THROW(base_field.get<psim::Integer>(), std::runtime_error);
     //   ^ throws a static assertion error
   }
@@ -155,7 +155,7 @@ TEST(StateField, TestGet) {
   {
     psim::StateField<psim::Real> const &base_field = field;
 
-    ASSERT_EQ(base_field.get<psim::Real>(), 2.0);
+    ASSERT_EQ(base_field.template get<psim::Real>(), 2.0);
     // EXPECT_THROW(base_field.get<psim::Integer>(), std::runtime_error);
     //   ^ throws a static assertion error
   }
@@ -170,14 +170,14 @@ TEST(StateField, TestGetWritable) {
     {
       psim::StateFieldBase &base_field = field;
 
-      EXPECT_THROW(base_field.get_writable<psim::Real>(), std::runtime_error);
+      EXPECT_THROW(base_field.template get_writable<psim::Real>(), std::runtime_error);
     }
 
     // Test for `StateField`
     {
       psim::StateField<psim::Real> &base_field = field;
 
-      EXPECT_THROW(base_field.get_writable<psim::Real>(), std::runtime_error);
+      EXPECT_THROW(base_field.template get_writable<psim::Real>(), std::runtime_error);
     }
   }
 
@@ -189,15 +189,15 @@ TEST(StateField, TestGetWritable) {
     {
       psim::StateFieldBase &base_field = field;
 
-      ASSERT_EQ(base_field.get_writable<psim::Real>(), 2.0);
-      EXPECT_THROW(base_field.get_writable<psim::Integer>(), std::runtime_error);
+      ASSERT_EQ(base_field.template get_writable<psim::Real>(), 2.0);
+      EXPECT_THROW(base_field.template get_writable<psim::Integer>(), std::runtime_error);
     }
 
     // Test for `StateField`
     {
       psim::StateField<psim::Real> &base_field = field;
 
-      ASSERT_EQ(base_field.get_writable<psim::Real>(), 2.0);
+      ASSERT_EQ(base_field.template get_writable<psim::Real>(), 2.0);
       // EXPECT_THROW(base_field.get_writable<psim::Integer>(), std::runtime_error);
       //   ^ throws a static assertion error
     }

--- a/tools/autocoder.py
+++ b/tools/autocoder.py
@@ -135,7 +135,7 @@ class Parameter(Variable):
     @property
     def constructor(self):
         if not self.__constructor:
-            self.__constructor = self.member_name + '(config[' + self.string_name + '].get<' + self.underlying_type + '>())'
+            self.__constructor = self.member_name + '(config[' + self.string_name + '].template get<' + self.underlying_type + '>())'
 
         return self.__constructor
 
@@ -210,7 +210,7 @@ class AddsStateField(StateField):
                 self.__constructor = self.member_name + '(' + self.string_name + ', std::bind(&D::' + self.member_name + ', &derived()))'
             else:
                 if self.is_initialized:
-                    self.__constructor = self.member_name + '(' + self.string_name + ', config[' + self.string_name + '].get<' + self.underlying_type + '>())'
+                    self.__constructor = self.member_name + '(' + self.string_name + ', config[' + self.string_name + '].template get<' + self.underlying_type + '>())'
                 else:
                     self.__constructor = self.member_name + '(' + self.string_name + ')'
 


### PR DESCRIPTION
Fixes #257.

## Summary of Changes

* Update lin pointer to include compatibility fixes.
* Include the `template` keyword on calls to `get<...>`, `cast<...>`, et cetera.