### PR TITLE
Make Simulation Configuration Editable from Python

### DIFF
--- a/include/psim/core/configuration.hpp
+++ b/include/psim/core/configuration.hpp
@@ -35,44 +35,49 @@
 #include "types.hpp"
 
 #include <functional>
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
 namespace psim {
 
-/** @brief Represents a set of parameters used to initialize a simulation.
- *
- *  A configuration is a set of parameters parsed from a configuration file.
- *  These parameters are made accesible to the simulation's models during
- *  intialization to specify initial conditions and configure constants.
- */
 class Configuration {
  private:
-  /** @brief Map containing the parameter pointers.
-   *
-   *  https://stackoverflow.com/questions/9139748/using-stdreference-wrapper-as-the-key-in-a-stdmap
-   */
-  std::unordered_map<std::reference_wrapper<std::string const>,
-      ParameterBase const *, std::hash<std::string>, std::equal_to<std::string>>
-      _parameters;
-
-  Configuration() = default;
-
   template <typename T>
   void _add(std::string const &name, T &&value, std::string const &file,
       std::size_t l);
+
+ protected:
+  std::unordered_map<std::reference_wrapper<std::string const>,
+                     std::unique_ptr<ParameterBase const>,
+                     std::hash<std::string>, std::equal_to<std::string>>
+                     _parameters;
+
+  Configuration() = default;
 
   void _parse(std::string const &file);
 
  public:
   Configuration(Configuration const &) = delete;
-  Configuration &operator=(Configuration const &) = delete;
+  Configuration & operator=(Configuration const &) = delete;
 
-  Configuration(Configuration &&config);
-  Configuration &operator=(Configuration &&config);
+  Configuration(Configuration &&) = default;
+  Configuration &operator=(Configuration &&) = default;
 
-  virtual ~Configuration();
+  virtual ~Configuration() = default;
+
+  /** @brief
+   *
+   *  @param[in] file
+   */
+  Configuration(std::string const &file);
+
+  /** @brief
+   *
+   *  @param[in] files
+   */
+  Configuration(std::vector<std::string> const &files);
 
   /** @brief Retrives a parameter by name.
    *
@@ -94,28 +99,6 @@ class Configuration {
    *  If no parameter is found by the specified name, a runtime error is thrown.
    */
   ParameterBase const &operator[](std::string const &name) const;
-
-  /** @brief Parses a configuration file into a set of parameters.
-   *
-   *  @param[in] file Configuration file.
-   *
-   *  @return Parameters.
-   *
-   *  If the configuration file doesn't exist, a line with invalid formatting is
-   *  found, or a particular key is specified twice, a runtime error will be
-   *  thrown.
-   */
-  static Configuration make(std::string const &file);
-
-  /** @brief Parses a set of configuration files into a set of parameters.
-   *
-   *  @param[in] files Set of configuration file names.
-   *
-   *  If one of the configuration files don't exist, a line with invalid
-   *  formatting is found, or a particular key is specified twice, a runtime
-   *  error will be thrown.
-   */
-  static Configuration make(std::vector<std::string> const &files);
 };
 } // namespace psim
 

--- a/include/psim/core/configuration.hpp
+++ b/include/psim/core/configuration.hpp
@@ -42,6 +42,12 @@
 
 namespace psim {
 
+/** @brief Represents a set of parameters used to initialize a simulation.
+ *
+ *  A configuration is a set of parameters parsed from a configuration file.
+ *  These parameters are made accesible to the simulation's models during
+ *  intialization to specify initial conditions and configure constants.
+ */
 class Configuration {
  private:
   template <typename T>
@@ -49,6 +55,10 @@ class Configuration {
       std::size_t l);
 
  protected:
+  /** @brief Map containing the parameter pointers.
+   *
+   *  https://stackoverflow.com/questions/9139748/using-stdreference-wrapper-as-the-key-in-a-stdmap
+   */
   std::unordered_map<std::reference_wrapper<std::string const>,
                      std::unique_ptr<ParameterBase const>,
                      std::hash<std::string>, std::equal_to<std::string>>
@@ -67,15 +77,23 @@ class Configuration {
 
   virtual ~Configuration() = default;
 
-  /** @brief
+  /** @brief Parses a configuration file into a configuration.
    *
-   *  @param[in] file
+   *  @param[in] file Configuration file.
+   *
+   *  If the configuration file doesn't exist, a line with invalid formatting is
+   *  found, or a particular key is specified twice, a runtime error will be
+   *  thrown.
    */
   Configuration(std::string const &file);
 
-  /** @brief
+  /** @brief Parses a set of configuration files into a configuration.
    *
-   *  @param[in] files
+   *  @param[in] files Set of configuration file names.
+   *
+   *  If one of the configuration files don't exist, a line with invalid
+   *  formatting is found, or a particular key is specified twice, a runtime
+   *  error will be thrown.
    */
   Configuration(std::vector<std::string> const &files);
 

--- a/python/psim/__init__.py
+++ b/python/psim/__init__.py
@@ -9,6 +9,7 @@ from .plugins import (
 )
 
 from .simulation import (
+    Configuration,
     Simulation,
     SimulationRunner,
 )

--- a/python/psim/simulation.py
+++ b/python/psim/simulation.py
@@ -38,10 +38,10 @@ class Simulation(object):
     This is the recommended entrypoint if you're not interested in using the
     plugin system and don't want to use the simulation runner.
     """
-    def __init__(self, sim, configs):
+    def __init__(self, sim, config):
         super(Simulation, self).__init__()
 
-        self._sim = sim(Configuration(configs))
+        self._sim = sim(config)
 
     def __getitem__(self, name):
         """Retrieves a state field from the underlying simulation.
@@ -120,7 +120,7 @@ class SimulationRunner(object):
         log.debug('Simulation type set to "%s"', str(sim))
 
         # Construct the simulation
-        self._sim = Simulation(sim, configs)
+        self._sim = Simulation(sim, Configuration(configs))
 
         # Initialize plugins
         for plugin in self._plugins:

--- a/src/psim/_psim/configuration.cpp
+++ b/src/psim/_psim/configuration.cpp
@@ -49,8 +49,6 @@ class PyConfiguration : public psim::Configuration {
  public:
   using psim::Configuration::Configuration;
 
-  PyConfiguration() = default;
-
   virtual ~PyConfiguration() = default;
 
   PyVariant get(std::string const &name) {

--- a/src/psim/_psim/configuration.cpp
+++ b/src/psim/_psim/configuration.cpp
@@ -88,7 +88,7 @@ class PyConfiguration : public psim::Configuration {
 };
 
 void py_configuration(py::module &m) {
-  py::class_<PyConfiguration, psim::Configuration>(m, "Configuration")
+  py::class_<psim::Configuration, PyConfiguration>(m, "Configuration")
     .def(py::init([](std::string const &file) { return new PyConfiguration; }))
     .def(py::init([](std::string const &file) { return new PyConfiguration(file); }))
     .def(py::init([](std::vector<std::string> const &files) { return new PyConfiguration(files); }))

--- a/src/psim/_psim/configuration.cpp
+++ b/src/psim/_psim/configuration.cpp
@@ -89,7 +89,7 @@ class PyConfiguration : public psim::Configuration {
 
 void py_configuration(py::module &m) {
   py::class_<psim::Configuration, PyConfiguration>(m, "Configuration")
-    .def(py::init([](std::string const &file) { return new PyConfiguration; }))
+    .def(py::init([]() { return new PyConfiguration; }))
     .def(py::init([](std::string const &file) { return new PyConfiguration(file); }))
     .def(py::init([](std::vector<std::string> const &files) { return new PyConfiguration(files); }))
     .def("__getitem__", [](PyConfiguration &self, std::string const &name) { return self.get(name); })

--- a/src/psim/_psim/configuration.cpp
+++ b/src/psim/_psim/configuration.cpp
@@ -38,34 +38,62 @@ namespace py = pybind11;
 
 using PyVariant = mapbox::util::variant<psim::Integer, psim::Real, psim::Vector2, psim::Vector3, psim::Vector4>;
 
-static PyVariant py_visit(psim::ParameterBase const &field) {
-  // TODO : Update this to use double dispatch or something else that's better
-  {
-    auto const *ptr = dynamic_cast<psim::Parameter<psim::Integer> const *>(&field);
-    if (ptr) return ptr->get();
+class PyConfiguration : public psim::Configuration {
+ private:
+  template <typename T>
+  void _set(std::string const &name, T const &value) {
+    auto param = std::make_unique<psim::Parameter<T>>(name, value);
+    _parameters[param->name()] = std::move(param);
   }
-  {
-    auto const *ptr = dynamic_cast<psim::Parameter<psim::Real> const *>(&field);
-    if (ptr) return ptr->get();
+
+ public:
+  using psim::Configuration::Configuration;
+
+  PyConfiguration() = default;
+
+  virtual ~PyConfiguration() = default;
+
+  PyVariant get(std::string const &name) {
+    auto const &field = (*this)[name];
+    {
+      auto const *ptr = dynamic_cast<psim::Parameter<psim::Integer> const *>(&field);
+      if (ptr) return ptr->get();
+    }
+    {
+      auto const *ptr = dynamic_cast<psim::Parameter<psim::Real> const *>(&field);
+      if (ptr) return ptr->get();
+    }
+    {
+      auto const *ptr = dynamic_cast<psim::Parameter<psim::Vector2> const *>(&field);
+      if (ptr) return ptr->get();
+    }
+    {
+      auto const *ptr = dynamic_cast<psim::Parameter<psim::Vector3> const *>(&field);
+      if (ptr) return ptr->get();
+    }
+    {
+      auto const *ptr = dynamic_cast<psim::Parameter<psim::Vector4> const *>(&field);
+      if (ptr) return ptr->get();
+    }
+    throw std::runtime_error("Attempted to retrieve state field of an unsupported type.");
   }
-  {
-    auto const *ptr = dynamic_cast<psim::Parameter<psim::Vector2> const *>(&field);
-    if (ptr) return ptr->get();
+
+  void set(std::string const &name, PyVariant const &value) {
+    value.match(
+      [this, &name](psim::Real    const &v) { _set(name, v); },
+      [this, &name](psim::Integer const &v) { _set(name, v); },
+      [this, &name](psim::Vector2 const &v) { _set(name, v); },
+      [this, &name](psim::Vector3 const &v) { _set(name, v); },
+      [this, &name](psim::Vector4 const &v) { _set(name, v); }
+    );
   }
-  {
-    auto const *ptr = dynamic_cast<psim::Parameter<psim::Vector3> const *>(&field);
-    if (ptr) return ptr->get();
-  }
-  {
-    auto const *ptr = dynamic_cast<psim::Parameter<psim::Vector4> const *>(&field);
-    if (ptr) return ptr->get();
-  }
-  throw std::runtime_error("Attempted to retrieve state field of an unsupported type.");
-}
+};
 
 void py_configuration(py::module &m) {
-  py::class_<psim::Configuration>(m, "Configuration")
-    .def(py::init([](std::string const &file) { return psim::Configuration::make(file); }))
-    .def(py::init([](std::vector<std::string> const &files) { return psim::Configuration::make(files); }))
-    .def("__getitem__", [](psim::Configuration const &self, std::string const &name) { return py_visit(self[name]); });
+  py::class_<PyConfiguration, psim::Configuration>(m, "Configuration")
+    .def(py::init([](std::string const &file) { return new PyConfiguration; }))
+    .def(py::init([](std::string const &file) { return new PyConfiguration(file); }))
+    .def(py::init([](std::vector<std::string> const &files) { return new PyConfiguration(files); }))
+    .def("__getitem__", [](PyConfiguration &self, std::string const &name) { return self.get(name); })
+    .def("__setitem__", [](PyConfiguration &self, std::string const &name, PyVariant const &value) { self.set(name, value); });
 }

--- a/test/psim/core/configuration_test.cpp
+++ b/test/psim/core/configuration_test.cpp
@@ -12,29 +12,29 @@
 TEST(Configuration, TestBadName) {
   std::string const file =
       "test/psim/core/configuration_test_bad_name_config.txt";
-  EXPECT_THROW(psim::Configuration::make(file), std::runtime_error);
+  EXPECT_THROW(psim::Configuration _(file), std::runtime_error);
 }
 
 TEST(Configuration, TestBadValue) {
   std::string const file =
       "test/psim/core/configuration_test_bad_value_config.txt";
-  EXPECT_THROW(psim::Configuration::make(file), std::runtime_error);
+  EXPECT_THROW(psim::Configuration _(file), std::runtime_error);
 }
 
 TEST(Configuration, TestDuplicateName) {
   std::string const file =
       "test/psim/core/configuration_test_duplicate_name_config.txt";
-  EXPECT_THROW(psim::Configuration::make(file), std::runtime_error);
+  EXPECT_THROW(psim::Configuration _(file), std::runtime_error);
 }
 
 TEST(Configuration, TestFieldNotFound) {
   std::string const file = "test/psim/core/configuration_test_dne_config.txt";
-  EXPECT_THROW(psim::Configuration::make(file), std::runtime_error);
+  EXPECT_THROW(psim::Configuration _(file), std::runtime_error);
 }
 
 TEST(Configuration, TestGet) {
   std::string const file = "test/psim/core/configuration_test_config.txt";
-  auto const config = psim::Configuration::make(file);
+  auto const config = psim::Configuration(file);
 
   // Test a proper access
   ASSERT_EQ(config.get("test.integer")->template get<psim::Integer>(), 1);
@@ -47,7 +47,7 @@ TEST(Configuration, TestMultiFileMake) {
   std::vector<std::string> const files = {
       "test/psim/core/configuration_test_config.txt",
       "test/psim/core/configuration_test_two_config.txt"};
-  auto const config = psim::Configuration::make(files);
+  auto const config = psim::Configuration(files);
 
   // Check Integer field(s) from both files
   {
@@ -69,7 +69,7 @@ TEST(Configuration, TestMultiFileMake) {
 
 TEST(Configuration, TestSingleFileMake) {
   std::string const file = "test/psim/core/configuration_test_config.txt";
-  auto const config = psim::Configuration::make(file);
+  auto const config = psim::Configuration(file);
 
   // Check Integer field(s)
   {

--- a/test/psim/core/simulation_test.cpp
+++ b/test/psim/core/simulation_test.cpp
@@ -12,7 +12,7 @@
 
 TEST(Simulation, TestStep) {
   auto const config =
-      psim::Configuration::make("test/psim/core/simulation_test_config.txt");
+      psim::Configuration("test/psim/core/simulation_test_config.txt");
   auto sim = psim::Simulation::make<Counter>(config);
 
   // Check initial conditions

--- a/test/psim/truth/time_test.cpp
+++ b/test/psim/truth/time_test.cpp
@@ -9,7 +9,7 @@
 #include <psim/truth/time.hpp>
 
 TEST(Time, TestStep) {
-  auto const config = psim::Configuration::make("test/psim/truth/time_test_config.txt");
+  auto const config = psim::Configuration("test/psim/truth/time_test_config.txt");
   auto sim = psim::Simulation::make<psim::Time>(config);
 
   // Assert intial conditions


### PR DESCRIPTION
Fixes #266.

# Make Simulation Configuration Editable from Python

Per the title, this change makes a simulation configuration object editable from Python. You can add and/or overwrite items in the configuration to whatever you prefer. Do note, however, that you can change the type of the underlying parameter as well!

I've also slightly refactored the `Simulation` interface - heads up on that @shihaocao. Now, you create the configuratoin yourself and pass it as an argument to the simulation like this:

    import lin, psim
    config = psim.Configuration(['config/deployment.txt', ...])
    sim = psim.Simulation(psim.sims.Type, config)

Here is a small test I did in the Python shell:

    @thinkpad ~/git/pan/psim git:(feature/update-parameters|+1) venv:(3.8.6)
    % python
    Python 3.8.6 (default, Sep 30 2020, 04:00:38)
    [GCC 10.2.0] on linux
    Type "help", "copyright", "credits" or "license" for more information.
    >>> import lin, psim
    >>> config = psim.Configuration()
    >>> config['test.integer'] = 5
    >>> config['test.integer']
    5
    >>> exit()

I also ran a single satellite attitude orbit case locally to verify the change!