### PR TITLE
GPS, Gyroscope, and Magnetometer Sensor Models

### DIFF
--- a/config/parameters/sensors/base.txt
+++ b/config/parameters/sensors/base.txt
@@ -1,24 +1,20 @@
 # Basic configuration information shared across all sensor model initial
 # conditions.
 #
+# All configuration values for the gyroscope and magnetometer were
+# experimentally determined. See the following folder in the PAN team google
+# drive:
+#   System Level > Integration and Testing > Sensor Charactarization
+#
 
 # Leader spacecraft base sensor configuration
 
 sensors.leader.gps.r.sigma  0.0 0.0 0.0
 
-# The source for these numbers is currectly Stewart's original attitude
-# estimator script written in MATLAB. This will be updated down the road
-# but the datasheet is still linked below.
-#
-# https://www.st.com/content/ccc/resource/technical/document/datasheet/76/27/cf/88/c5/03/42/6b/DM00218116.pdf/files/DM00218116.pdf/jcr:content/translations/en.DM00218116.pdf
 sensors.leader.gyroscope.w.bias        0.02    0.01    -0.03
 sensors.leader.gyroscope.w.bias.sigma  1.00e-6 1.00e-6  1.00e-6
 sensors.leader.gyroscope.w.sigma       2.75e-4 2.75e-4  2.75e-4
 
-# Pulled from the LIS3MDL datasheet. Note that the noises specified there are
-# 3.2e-, 3.2e-7, and 4.0e-7 respectively but we are being conservative here.
-#
-# https://www.st.com/resource/en/datasheet/lis3mdl.pdf
 sensors.leader.magnetometer.b.sigma  5.00e-7 5.00e-7 5.00e-7
 
 # Follower spacecraft base sensor configuration

--- a/config/parameters/sensors/base.txt
+++ b/config/parameters/sensors/base.txt
@@ -6,10 +6,19 @@
 
 sensors.leader.gps.r.sigma  0.0 0.0 0.0
 
+# The source for these numbers is currectly Stewart's original attitude
+# estimator script written in MATLAB. This will be updated down the road
+# but the datasheet is still linked below.
+#
+# https://www.st.com/content/ccc/resource/technical/document/datasheet/76/27/cf/88/c5/03/42/6b/DM00218116.pdf/files/DM00218116.pdf/jcr:content/translations/en.DM00218116.pdf
 sensors.leader.gyroscope.w.bias        0.02    0.01    -0.03
 sensors.leader.gyroscope.w.bias.sigma  1.00e-6 1.00e-6  1.00e-6
 sensors.leader.gyroscope.w.sigma       2.75e-4 2.75e-4  2.75e-4
 
+# Pulled from the LIS3MDL datasheet. Note that the noises specified there are
+# 3.2e-, 3.2e-7, and 4.0e-7 respectively but we are being conservative here.
+#
+# https://www.st.com/resource/en/datasheet/lis3mdl.pdf
 sensors.leader.magnetometer.b.sigma  5.00e-7 5.00e-7 5.00e-7
 
 # Follower spacecraft base sensor configuration

--- a/config/parameters/sensors/base.txt
+++ b/config/parameters/sensors/base.txt
@@ -1,10 +1,23 @@
-# Basic configuration information shared across all sensor model configurations.
+# Basic configuration information shared across all sensor model initial
+# conditions.
 #
 
 # Leader spacecraft base sensor configuration
 
-sensors.leader.gyroscope.bias  0.02 0.01 -0.03
+sensors.leader.gps.r.sigma  0.0 0.0 0.0
+
+sensors.leader.gyroscope.w.bias        0.02    0.01    -0.03
+sensors.leader.gyroscope.w.bias.sigma  1.00e-6 1.00e-6  1.00e-6
+sensors.leader.gyroscope.w.sigma       2.75e-4 2.75e-4  2.75e-4
+
+sensors.leader.magnetometer.b.sigma  5.00e-7 5.00e-7 5.00e-7
 
 # Follower spacecraft base sensor configuration
 
-sensors.follower.gyroscope.bias  -0.01 0.00 0.05
+sensors.follower.gps.r.sigma  0.0 0.0 0.0
+
+sensors.follower.gyroscope.w.bias        -0.01    0.01    0.04
+sensors.follower.gyroscope.w.bias.sigma   1.00e-6 1.00e-6 1.00e-6
+sensors.follower.gyroscope.w.sigma        2.75e-4 2.75e-4 2.75e-4
+
+sensors.follower.magnetometer.b.sigma  5.00e-7 5.00e-7 5.00e-7

--- a/config/plots/sensors/gyroscope.yml
+++ b/config/plots/sensors/gyroscope.yml
@@ -5,7 +5,7 @@
 
 # Gyroscope bias over time.
 - x: truth.t.s
-  y: [sensors.leader.gyroscope.bias.x, sensors.leader.gyroscope.bias.y, sensors.leader.gyroscope.bias.z]
+  y: [sensors.leader.gyroscope.w.bias.x, sensors.leader.gyroscope.w.bias.y, sensors.leader.gyroscope.w.bias.z]
 
 # Gyroscope measurement error over time.
 - x: truth.t.s

--- a/include/psim/sensors/gps_no_attitude.yml
+++ b/include/psim/sensors/gps_no_attitude.yml
@@ -8,6 +8,12 @@ comment: >
 args:
     - satellite
 
+params:
+    - name: "sensors.{satellite}.gps.r.sigma"
+      type: Vector3
+      comment: >
+        Standard deviation of the position reading from the GPS.
+
 adds:
     - name: "sensors.{satellite}.gps.r"
       type: Lazy Vector3

--- a/include/psim/sensors/gyroscope.yml
+++ b/include/psim/sensors/gyroscope.yml
@@ -8,12 +8,24 @@ comment: >
 args:
     - satellite
 
+params:
+    - name: "sensors.{satellite}.gyroscope.w.sigma"
+      type: Vector3
+      comment: >
+        Standard deviation of the angular rate reading from the gyroscope. This
+        is white noise independent of the bias model.
+    - name: "sensors.{satellite}.gyroscope.w.bias.sigma"
+      type: Vector3
+      comment: >
+        Standard deviation of the noise integrated to simulate the gyroscope
+        bias' random walk over time.
+
 adds:
     - name: "sensors.{satellite}.gyroscope.w"
       type: Lazy Vector3
       comment: >
           Angular rate reported by the gyroscope in the body frame.
-    - name: "sensors.{satellite}.gyroscope.bias"
+    - name: "sensors.{satellite}.gyroscope.w.bias"
       type: Initialized Vector3
       comment: >
           Bias exhibited by the gyroscope readings in the body frame. This
@@ -25,5 +37,7 @@ adds:
           Error in the angular rate reported by the gyroscope in the body frame.
 
 gets:
+    - name: "truth.dt.s"
+      type: Real
     - name: "truth.{satellite}.attitude.w"
       type: Vector3

--- a/include/psim/sensors/magnetometer.yml
+++ b/include/psim/sensors/magnetometer.yml
@@ -8,6 +8,12 @@ comment: >
 args:
     - satellite
 
+params:
+    - name: "sensors.{satellite}.magnetometer.b.sigma"
+      type: Vector3
+      comment: >
+        Standard deviation of the magnetic field reading from the magnetometer.
+
 adds:
     - name: "sensors.{satellite}.magnetometer.b"
       type: Lazy Vector3

--- a/src/psim/sensors/gps_no_attitude.cpp
+++ b/src/psim/sensors/gps_no_attitude.cpp
@@ -32,9 +32,9 @@ namespace psim {
 
 Vector3 GpsNoAttitude::sensors_satellite_gps_r() const {
   auto const &truth_r_ecef = truth_satellite_orbit_r_ecef->get();
+  auto const &sigma = sensors_satellite_gps_r_sigma.get();
 
-  // TODO : Implement a configurable white noise model
-  return truth_r_ecef;
+  return truth_r_ecef + lin::multiply(sigma, lin::gaussians<Vector3>(_randoms));
 }
 
 Vector3 GpsNoAttitude::sensors_satellite_gps_r_error() const {

--- a/src/psim/sensors/gyroscope.cpp
+++ b/src/psim/sensors/gyroscope.cpp
@@ -33,15 +33,19 @@ namespace psim {
 void Gyroscope::step() {
   this->Super::step();
 
-  // TODO : Implement gyroscope bias drift
+  auto       &bias = sensors_satellite_gyroscope_w_bias.get();
+  auto const &bias_sigma = sensors_satellite_gyroscope_w_bias_sigma.get();
+  auto const &dt = truth_dt_s->get();
+
+  bias = bias + dt * lin::multiply(bias_sigma, lin::gaussians<Vector3>(_randoms));
 }
 
 Vector3 Gyroscope::sensors_satellite_gyroscope_w() const {
   auto const &truth_w = truth_satellite_attitude_w->get();
-  auto const &bias = sensors_satellite_gyroscope_bias.get();
+  auto const &bias = sensors_satellite_gyroscope_w_bias.get();
+  auto const &sigma = sensors_satellite_gyroscope_w_sigma.get();
 
-  // TODO : Implement a white noise model
-  return truth_w + bias;
+  return truth_w + bias + lin::multiply(sigma, lin::gaussians<Vector3>(_randoms));
 }
 
 Vector3 Gyroscope::sensors_satellite_gyroscope_w_error() const {

--- a/src/psim/sensors/magnetometer.cpp
+++ b/src/psim/sensors/magnetometer.cpp
@@ -32,9 +32,9 @@ namespace psim {
 
 Vector3 Magnetometer::sensors_satellite_magnetometer_b() const {
   auto const &truth_b = truth_satellite_environment_b_body->get();
+  auto const &sigma = sensors_satellite_magnetometer_b_sigma.get();
 
-  // TODO : Implement a configurable white noise model
-  return truth_b;
+  return truth_b + lin::multiply(sigma, lin::gaussians<Vector3>(_randoms));
 }
 
 Vector3 Magnetometer::sensors_satellite_magnetometer_b_error() const {


### PR DESCRIPTION
# GPS, Gyroscope, and Magnetometer Sensor Models

Simple sensors models were implemented for the three sensors specified in the title above. Both the GPS and magnetometer models are just white noise models at the moment. We should moving forward add in dependence on the MTRs for the magnetometer model.

The gyroscope model is based off of Stewarts model he used during development of the attitude filter. It's a white noise model added on top of a hard offset (bias) that randomly walks over time.

All of the noise parameters are configurable via the simulation config prior to initialization!

I've attached some plots below showing the sensor model's error over time for the gyroscope and magnetometer. The command ran to obtain them was:

    python -m psim -s 1000 -p sensors/gps,sensors/gyroscope,sensors/magnetometer -ps 1 -c sensors/base,truth/base,truth/deployment SingleAttitudeOrbitGnc

![gyr](https://user-images.githubusercontent.com/33558436/100480836-674ebe80-30c0-11eb-8613-48e919a3676f.png)
![gyr_err](https://user-images.githubusercontent.com/33558436/100480837-67e75500-30c0-11eb-9564-cbc86074b401.png)
![mag](https://user-images.githubusercontent.com/33558436/100480839-67e75500-30c0-11eb-9306-44d25979ba0c.png)
![mag_err](https://user-images.githubusercontent.com/33558436/100480840-67e75500-30c0-11eb-97ed-e7f3cf6ef072.png)
