### PR TITLE
Attitude Estimator Model

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -37,10 +37,10 @@ psim_cc_library(
     visibility = ["//visibility:public"],
 )
 
-# Builds the PSim sensor models
+# Builds the PSim utilities models
 psim_autocoded_cc_library(
-    name = "sensors",
-    deps = ["@lin//:lin", "//:gnc", "//:psim_core", "//:psim_utilities"],
+    name = "utilities",
+    deps = ["@lin//:lin", "//:gnc", "//:psim_core"],
     visibility = ["//visibility:public"],
 )
 
@@ -51,10 +51,17 @@ psim_autocoded_cc_library(
     visibility = ["//visibility:public"],
 )
 
-# Builds the PSim utilities models
+# Builds the PSim sensor models
 psim_autocoded_cc_library(
-    name = "utilities",
-    deps = ["@lin//:lin", "//:gnc", "//:psim_core"],
+    name = "sensors",
+    deps = ["@lin//:lin", "//:gnc", "//:psim_core", "//:psim_utilities"],
+    visibility = ["//visibility:public"],
+)
+
+# Builds the PSim flight computer models
+psim_autocoded_cc_library(
+    name = "fc",
+    deps = ["@lin//:lin", "//:gnc", "//:psim_core", "//:psim_utilities"],
     visibility = ["//visibility:public"],
 )
 
@@ -62,8 +69,8 @@ psim_autocoded_cc_library(
 psim_cc_library(
     name = "simulations",
     deps = [
-        "//:psim_core", "//:psim_sensors", "//:psim_truth",
-        "//:psim_utilities"
+        "//:psim_core", "//:psim_utilities", "//:psim_truth", "//:psim_sensors",
+        "//:psim_fc"
     ],
     visibility = ["//visibility:public"],
 )

--- a/config/plots/fc/attitude.yml
+++ b/config/plots/fc/attitude.yml
@@ -1,0 +1,4 @@
+
+# Attitude estimator's validity over time.
+- x: truth.t.s
+  y: fc.leader.attitude.is_valid

--- a/include/psim/fc/attitude_estimator.hpp
+++ b/include/psim/fc/attitude_estimator.hpp
@@ -1,0 +1,66 @@
+//
+// MIT License
+//
+// Copyright (c) 2020 Pathfinder for Autonomous Navigation (PAN)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+/** @file psim/fc/attitude_estimator.hpp
+ *  @author Kyle Krol
+ */
+
+#ifndef PSIM_FC_ATTITUDE_ESTIMATOR_HPP_
+#define PSIM_FC_ATTITUDE_ESTIMATOR_HPP_
+
+#include <psim/fc/attitude_estimator.yml.hpp>
+
+#include <gnc/attitude_estimator.hpp>
+
+namespace psim {
+
+class AttitudeEstimator : public AttitudeEstimatorInterface<AttitudeEstimator> {
+ private:
+  typedef AttitudeEstimatorInterface<AttitudeEstimator> Super;
+
+  gnc::AttitudeEstimatorState _attitude_state;
+  gnc::AttitudeEstimatorData _attitude_data;
+  gnc::AttitudeEstimate _attitude_estimate;
+
+  void _set_attitude_outputs();
+
+ public:
+  using Super::AttitudeEstimatorInterface;
+
+  AttitudeEstimator() = delete;
+  virtual ~AttitudeEstimator() = default;
+
+  virtual void add_fields(State &state) override;
+  virtual void step() override;
+
+  Vector4 fc_satellite_attitude_q_body_eci_error() const;
+  Real fc_satellite_attitude_q_body_eci_error_degrees() const;
+  Vector3 fc_satellite_attitude_p_body_eci_error() const;
+  Vector3 fc_satellite_attitude_p_body_eci_sigma() const;
+  Vector3 fc_satellite_attitude_w_bias_error() const;
+  Vector3 fc_satellite_attitude_w_bias_sigma() const;
+};
+} // namespace psim
+
+#endif

--- a/include/psim/fc/attitude_estimator.hpp
+++ b/include/psim/fc/attitude_estimator.hpp
@@ -58,6 +58,8 @@ class AttitudeEstimator : public AttitudeEstimatorInterface<AttitudeEstimator> {
   Real fc_satellite_attitude_q_body_eci_error_degrees() const;
   Vector3 fc_satellite_attitude_p_body_eci_error() const;
   Vector3 fc_satellite_attitude_p_body_eci_sigma() const;
+  Vector3 fc_satellite_attitude_w() const;
+  Vector3 fc_satellite_attitude_w_error() const;
   Vector3 fc_satellite_attitude_w_bias_error() const;
   Vector3 fc_satellite_attitude_w_bias_sigma() const;
 };

--- a/include/psim/fc/attitude_estimator.yml
+++ b/include/psim/fc/attitude_estimator.yml
@@ -1,0 +1,67 @@
+
+name: AttitudeEstimatorInterface
+type: Model
+comment: >
+    Interface for how the flight computer's attitude estimator will interact
+    with the simulation in PSim standalone.
+
+args:
+    - satellite
+
+adds:
+    - name: "fc.{satellite}.attitude.is_valid"
+      type: Integer
+      comment: >
+        Flag specifying whether or not the estimator is currently initialized.
+        Zero indicated the estimator isn't initialized while one indicates it
+        has been initialized.
+    - name: "fc.{satellite}.attitude.q.body_eci"
+      type: Vector4
+      comment: >
+        Current attitude estimate.
+    - name: "fc.{satellite}.attitude.q.body_eci.error"
+      type: Lazy Vector4
+      comment: >
+        Current attitude estimate error.
+    - name: "fc.{satellite}.attitude.q.body_eci.error.degrees"
+      type: Lazy Real
+      comment: >
+        Current attitude estimate error represented as a scalar in degrees.
+    - name: "fc.{satellite}.attitude.p.body_eci.error"
+      type: Lazy Vector3
+      comment: >
+        Current attitude estimate error. This value is represented as a
+        Generalized Rodrigues Parameter.
+    - name: "fc.{satellite}.attitude.p.body_eci.sigma"
+      type: Lazy Vector3
+      comment: >
+        One sigma bounds on the current attitude estimate error. This value is
+        represented as a Generalized Rodrigues Parameter.
+    - name: "fc.{satellite}.attitude.w.bias"
+      type: Vector3
+      comment: >
+        Current angular rate bias estimate.
+    - name: "fc.{satellite}.attitude.w.bias.error"
+      type: Lazy Vector3
+      comment: >
+        Current angular rate bias estimate error.
+    - name: "fc.{satellite}.attitude.w.bias.sigma"
+      type: Lazy Vector3
+      comment: >
+        One sigma bounds on the current angular rate bias estimate error.
+
+gets:
+    - name: "truth.t.s"
+      type: Real
+    - name: "truth.{satellite}.orbit.r.ecef"
+      type: Vector3
+    - name: "truth.{satellite}.attitude.q.eci_body"
+      type: Vector4
+    - name: "sensors.{satellite}.gyroscope.w"
+      type: Vector3
+    - name: "sensors.{satellite}.gyroscope.w.bias"
+      type: Vector3
+    - name: "sensors.{satellite}.sun_sensors.s"
+      type: Vector3
+    - name: "sensors.{satellite}.magnetometer.b"
+      type: Vector3

--- a/include/psim/fc/attitude_estimator.yml
+++ b/include/psim/fc/attitude_estimator.yml
@@ -37,11 +37,11 @@ adds:
       comment: >
         One sigma bounds on the current attitude estimate error. This value is
         represented as a Generalized Rodrigues Parameter.
-    - name: "fc.satellite.attitude.w"
+    - name: "fc.{satellite}.attitude.w"
       type: Lazy Vector3
       comment: >
         Current angular rate estimate.
-    - name: "fc.satellite.attitude.w.error"
+    - name: "fc.{satellite}.attitude.w.error"
       type: Lazy Vector3
       comment: >
         Current angular rate estimate error.

--- a/include/psim/fc/attitude_estimator.yml
+++ b/include/psim/fc/attitude_estimator.yml
@@ -37,6 +37,14 @@ adds:
       comment: >
         One sigma bounds on the current attitude estimate error. This value is
         represented as a Generalized Rodrigues Parameter.
+    - name: "fc.satellite.attitude.w"
+      type: Lazy Vector3
+      comment: >
+        Current angular rate estimate.
+    - name: "fc.satellite.attitude.w.error"
+      type: Lazy Vector3
+      comment: >
+        Current angular rate estimate error.
     - name: "fc.{satellite}.attitude.w.bias"
       type: Vector3
       comment: >
@@ -57,6 +65,8 @@ gets:
       type: Vector3
     - name: "truth.{satellite}.attitude.q.eci_body"
       type: Vector4
+    - name: "truth.{satellite}.attitude.w"
+      type: Vector3
     - name: "sensors.{satellite}.gyroscope.w"
       type: Vector3
     - name: "sensors.{satellite}.gyroscope.w.bias"

--- a/include/psim/simulations/attitude_estimator_test.hpp
+++ b/include/psim/simulations/attitude_estimator_test.hpp
@@ -1,0 +1,50 @@
+//
+// MIT License
+//
+// Copyright (c) 2020 Pathfinder for Autonomous Navigation (PAN)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+/** @file psim/simulation/attitude_estimator_test.hpp
+ *  @author Kyle Krol
+ */
+
+#ifndef PSIM_SIMULATIONS_ATTITUDE_ESTIMATOR_TEST_HPP_
+#define PSIM_SIMULATIONS_ATTITUDE_ESTIMATOR_TEST_HPP_
+
+#include <psim/core/configuration.hpp>
+#include <psim/core/model_list.hpp>
+
+namespace psim {
+
+/** @brief Models attitude and orbital dynamics of a single spacecraft in order
+ *         to test the attitude estimator.
+ */
+class AttitudeEstimatorTestGnc : public ModelList {
+ public:
+  AttitudeEstimatorTestGnc() = delete;
+  virtual ~AttitudeEstimatorTestGnc() = default;
+
+  AttitudeEstimatorTestGnc(
+      RandomsGenerator &randoms, Configuration const &config);
+};
+} // namespace psim
+
+#endif

--- a/python/psim/_psim.cpp
+++ b/python/psim/_psim.cpp
@@ -34,6 +34,7 @@
 #include <psim/core/state_field.hpp>
 #include <psim/core/types.hpp>
 
+#include <psim/simulations/attitude_estimator_test.hpp>
 #include <psim/simulations/dual_attitude_orbit.hpp>
 #include <psim/simulations/dual_orbit.hpp>
 #include <psim/simulations/single_attitude_orbit.hpp>
@@ -184,6 +185,7 @@ static void py_assign(psim::StateFieldWritableBase &field, T const &value) {
       })
 
 void py_simulation(py::module &m) {
+  PY_SIMULATION(AttitudeEstimatorTestGnc);
   PY_SIMULATION(SingleAttitudeOrbitGnc);
   PY_SIMULATION(SingleOrbitGnc);
   PY_SIMULATION(DualAttitudeOrbitGnc);

--- a/python/psim/sims.py
+++ b/python/psim/sims.py
@@ -2,6 +2,7 @@
 """
 
 from _psim import (
+    AttitudeEstimatorTestGnc,
     DualAttitudeOrbitGnc,
     DualOrbitGnc,
     SingleAttitudeOrbitGnc,

--- a/src/psim/fc/attitude_estimator.cpp
+++ b/src/psim/fc/attitude_estimator.cpp
@@ -117,6 +117,20 @@ Vector3 AttitudeEstimator::fc_satellite_attitude_p_body_eci_sigma() const {
   return {lin::sqrt(P(0, 0)), lin::sqrt(P(1, 1)), lin::sqrt(P(2, 2))};
 }
 
+Vector3 AttitudeEstimator::fc_satellite_attitude_w() const {
+  auto const &bias = fc_satellite_attitude_w_bias.get();
+  auto const &sensors_w = sensors_satellite_gyroscope_w->get();
+
+  return sensors_w - bias;
+}
+
+Vector3 AttitudeEstimator::fc_satellite_attitude_w_error() const {
+  auto const &w = Super::fc_satellite_attitude_w.get();
+  auto const &truth_w = truth_satellite_attitude_w->get();
+
+  return w - truth_w;
+}
+
 Vector3 AttitudeEstimator::fc_satellite_attitude_w_bias_error() const {
   auto const &truth_bias = sensors_satellite_gyroscope_w_bias->get();
   auto const &bias = fc_satellite_attitude_w_bias.get();

--- a/src/psim/fc/attitude_estimator.cpp
+++ b/src/psim/fc/attitude_estimator.cpp
@@ -28,6 +28,7 @@
 
 #include <psim/fc/attitude_estimator.hpp>
 
+#include <gnc/constants.hpp>
 #include <gnc/utilities.hpp>
 
 #include <lin/core.hpp>
@@ -95,7 +96,8 @@ Vector4 AttitudeEstimator::fc_satellite_attitude_q_body_eci_error() const {
 Real AttitudeEstimator::fc_satellite_attitude_q_body_eci_error_degrees() const {
   auto const &q_error = Super::fc_satellite_attitude_q_body_eci_error.get();
 
-  return 2.0 * lin::asin(lin::norm(lin::ref<3, 1>(q_error, 0, 0)));
+  return 2.0 * gnc::constant::rad_to_deg *
+         lin::asin(lin::norm(lin::ref<3, 1>(q_error, 0, 0)));
 }
 
 Vector3 AttitudeEstimator::fc_satellite_attitude_p_body_eci_error() const {

--- a/src/psim/fc/attitude_estimator.cpp
+++ b/src/psim/fc/attitude_estimator.cpp
@@ -1,0 +1,130 @@
+//
+// MIT License
+//
+// Copyright (c) 2020 Pathfinder for Autonomous Navigation (PAN)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+/** @file psim/fc/attitude_estimator.cpp
+ *  @author Kyle Krol
+ */
+
+#include <psim/fc/attitude_estimator.hpp>
+
+#include <gnc/utilities.hpp>
+
+#include <lin/core.hpp>
+#include <lin/math.hpp>
+#include <lin/queries.hpp>
+#include <lin/references.hpp>
+
+namespace psim {
+
+void AttitudeEstimator::_set_attitude_outputs() {
+  fc_satellite_attitude_is_valid.get() = _attitude_estimate.is_valid;
+  fc_satellite_attitude_q_body_eci.get() = _attitude_estimate.q_body_eci;
+  fc_satellite_attitude_w_bias.get() = _attitude_estimate.gyro_bias;
+}
+
+void AttitudeEstimator::add_fields(State &state) {
+  this->Super::add_fields(state);
+
+  // This ensures upon simulation construction the state fields hold proper
+  // values.
+  _set_attitude_outputs();
+}
+
+void AttitudeEstimator::step() {
+  this->Super::step();
+
+  auto const &t = truth_t_s->get();
+  auto const &r = truth_satellite_orbit_r_ecef->get();
+  auto const &b = sensors_satellite_magnetometer_b->get();
+  auto const &s = sensors_satellite_sun_sensors_s->get();
+  auto const &w = sensors_satellite_gyroscope_w->get();
+
+  // If the current estimate is already valid, update it.
+  if (_attitude_state.is_valid) {
+    _attitude_data = gnc::AttitudeEstimatorData();
+    _attitude_data.t = t;
+    _attitude_data.r_ecef = r;
+    _attitude_data.b_body = b;
+    _attitude_data.s_body = s;
+    _attitude_data.w_body = w;
+
+    _attitude_estimate = gnc::AttitudeEstimate();
+    gnc::attitude_estimator_update(
+        _attitude_state, _attitude_data, _attitude_estimate);
+  }
+  // Attempt to reset the current estimate if it isn't valid.
+  else {
+    if (lin::all(lin::isfinite(t)) && lin::all(lin::isfinite(r)) &&
+        lin::all(lin::isfinite(b)) && lin::all(lin::isfinite(s)))
+      gnc::attitude_estimator_reset(_attitude_state, t, r, b, s);
+  }
+
+  _set_attitude_outputs();
+}
+
+Vector4 AttitudeEstimator::fc_satellite_attitude_q_body_eci_error() const {
+  auto const &truth_q_eci_body = truth_satellite_attitude_q_eci_body->get();
+  auto const &q_body_eci = Super::fc_satellite_attitude_q_body_eci.get();
+
+  Vector4 q_error;
+  gnc::utl::quat_cross_mult(q_body_eci, truth_q_eci_body, q_error);
+  return q_error;
+}
+
+Real AttitudeEstimator::fc_satellite_attitude_q_body_eci_error_degrees() const {
+  auto const &q_error = Super::fc_satellite_attitude_q_body_eci_error.get();
+
+  return 2.0 * lin::asin(lin::norm(lin::ref<3, 1>(q_error, 0, 0)));
+}
+
+Vector3 AttitudeEstimator::fc_satellite_attitude_p_body_eci_error() const {
+  auto const &q_error = Super::fc_satellite_attitude_q_body_eci_error.get();
+
+  constexpr static Real a = 1.0;
+  constexpr static Real f = 2.0 * (a + 1.0);
+
+  Vector3 p_error;
+  gnc::utl::quat_to_qrp(q_error, a, f, p_error);
+  return p_error;
+}
+
+Vector3 AttitudeEstimator::fc_satellite_attitude_p_body_eci_sigma() const {
+  auto const &P = _attitude_state.P;
+
+  return {lin::sqrt(P(0, 0)), lin::sqrt(P(1, 1)), lin::sqrt(P(2, 2))};
+}
+
+Vector3 AttitudeEstimator::fc_satellite_attitude_w_bias_error() const {
+  auto const &truth_bias = sensors_satellite_gyroscope_w_bias->get();
+  auto const &bias = fc_satellite_attitude_w_bias.get();
+
+  return truth_bias - bias;
+}
+
+Vector3 AttitudeEstimator::fc_satellite_attitude_w_bias_sigma() const {
+  auto const &P = _attitude_state.P;
+
+  return {lin::sqrt(P(3, 3)), lin::sqrt(P(4, 4)), lin::sqrt(P(5, 5))};
+}
+} // namespace psim

--- a/src/psim/simulations/attitude_estimator_test.cpp
+++ b/src/psim/simulations/attitude_estimator_test.cpp
@@ -1,0 +1,42 @@
+//
+// MIT License
+//
+// Copyright (c) 2020 Pathfinder for Autonomous Navigation (PAN)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+/** @file psim/simulations/attitude_estimator_test.cpp
+ *  @author Kyle Krol
+ */
+
+#include <psim/simulations/attitude_estimator_test.hpp>
+
+#include <psim/fc/attitude_estimator.hpp>
+#include <psim/simulations/single_attitude_orbit.hpp>
+
+namespace psim {
+
+AttitudeEstimatorTestGnc::AttitudeEstimatorTestGnc(
+    RandomsGenerator &randoms, Configuration const &config)
+  : ModelList(randoms) {
+  add<SingleAttitudeOrbitGnc>(randoms, config);
+  add<AttitudeEstimator>(randoms, config, "leader");
+}
+} // namespace psim


### PR DESCRIPTION
# Attitude Estimator Model

Closes #197.

Pairs with #287 and #288.

### Summary of Changes

- Added an `AttitudeEstimator` model to mimic the attitude estimator running on the flight computer. More telemetry is exposed as runtime than is available off the flight computer itself.
- Added a new simulation `AttitudeEstimatorTestGnc` to actually run tests.

Note that most of the lazily evaluated fields simply facilitate checks on filter health. They are designed to mimic the plots @stewartaslan provided in his old MATLAB script.

### Testing

See the plots included with #287 as well as the screenshot below.

![everything](https://user-images.githubusercontent.com/33558436/103849531-f31a1a00-5072-11eb-9678-2afbb1211140.png)