### PR TITLE
Improved Sun Sensors Model

### DIFF
--- a/config/parameters/sensors/base.txt
+++ b/config/parameters/sensors/base.txt
@@ -6,6 +6,12 @@
 # drive:
 #   System Level > Integration and Testing > Sensor Charactarization
 #
+# The noise distribution for the sun sensors was chosen as two degrees, one
+# sigma. This matches the attitude filter's settings.
+#
+# Currently, we're not modelling eclipse with the sun sensors due to the
+# attitude estimators questionable performance. This will be updated later.
+#
 
 # Leader spacecraft base sensor configuration
 
@@ -17,6 +23,9 @@ sensors.leader.gyroscope.w.sigma       2.75e-4 2.75e-4  2.75e-4
 
 sensors.leader.magnetometer.b.sigma  5.00e-7 5.00e-7 5.00e-7
 
+sensors.leader.sun_sensors.model_eclipse  0
+sensors.leader.sun_sensors.s.sigma        0.0349066 0.0349066
+
 # Follower spacecraft base sensor configuration
 
 sensors.follower.gps.r.sigma  0.0 0.0 0.0
@@ -26,3 +35,6 @@ sensors.follower.gyroscope.w.bias.sigma   1.00e-6 1.00e-6 1.00e-6
 sensors.follower.gyroscope.w.sigma        2.75e-4 2.75e-4 2.75e-4
 
 sensors.follower.magnetometer.b.sigma  5.00e-7 5.00e-7 5.00e-7
+
+sensors.follower.sun_sensors.model_eclipse  0
+sensors.follower.sun_sensors.s.sigma        0.0349066 0.0349066

--- a/config/plots/sensors/sun_sensors.yml
+++ b/config/plots/sensors/sun_sensors.yml
@@ -1,0 +1,10 @@
+
+# Sun sensor's measurement over time.
+- type: Plot2D
+  x: truth.t.s
+  y: [sensors.leader.sun_sensors.s.x, sensors.leader.sun_sensors.s.y, sensors.leader.sun_sensors.s.z]
+
+# Sun sensor's measurement error over time.
+- type: Plot2D
+  x: truth.t.s
+  y: [sensors.leader.sun_sensors.s.error.x, sensors.leader.sun_sensors.s.error.y, sensors.leader.sun_sensors.s.error.z]

--- a/include/psim/sensors/sun_sensors.hpp
+++ b/include/psim/sensors/sun_sensors.hpp
@@ -44,6 +44,7 @@ class SunSensors : public SunSensorsInterface<SunSensors> {
   virtual ~SunSensors() = default;
 
   Vector3 sensors_satellite_sun_sensors_s() const;
+  Vector3 sensors_satellite_sun_sensors_s_error() const;
 };
 }  // namespace psim
 

--- a/include/psim/sensors/sun_sensors.yml
+++ b/include/psim/sensors/sun_sensors.yml
@@ -8,13 +8,36 @@ comment: >
 args:
     - satellite
 
+params:
+    - name: "sensors.{satellite}.sun_sensors.s.sigma"
+      type: Vector2
+      comment: >
+          Noise in terms of a spherical coordinate representation of the sun
+          vector. The noise affects the phi and theta angles in the body frame
+          currently.
+    - name: "sensors.{satellite}.sun_sensors.model_eclipse"
+      type: Integer
+      comment: >
+          Toggle whether or not being in eclipse prevents a sun vector from
+          being modelled.
+
 adds:
     - name: "sensors.{satellite}.sun_sensors.s"
       type: Lazy Vector3
       comment: >
           Sun vector reported by the sun sensors in the body frame. This vector
           is set to NaN if a sun vector cannot be determined.
+    - name: "sensors.{satellite}.sun_sensors.s.error"
+      type: Lazy Vector3
+      comment: >
+          Error in the sun vector reported by the sun sensors. Note, that the
+          error in being represented as the difference between two unit vectors
+          and therefore has an extra degree of freedom.
 
 gets:
     - name: "truth.{satellite}.environment.s.body"
+      type: Vector3
+    - name: "truth.{satellite}.environment.s.eci"
+      type: Vector3
+    - name: "truth.{satellite}.orbit.r.eci"
       type: Vector3

--- a/src/psim/sensors/sun_sensors.cpp
+++ b/src/psim/sensors/sun_sensors.cpp
@@ -28,12 +28,52 @@
 
 #include <psim/sensors/sun_sensors.hpp>
 
+#include <lin/core.hpp>
+#include <lin/generators.hpp>
+#include <lin/math.hpp>
+
 namespace psim {
 
 Vector3 SunSensors::sensors_satellite_sun_sensors_s() const {
-  auto const &truth_s = truth_satellite_environment_s_body->get();
+  /* Don't generate a sun vector measurement if in eclipse and the model is
+   * enabled.
+   *
+   * We consider ourselves to be in eclipse if the dot product of our position
+   * vector and the sun vector, both in ECI, is negative.
+   */
+  auto const &model_eclipse = sensors_satellite_sun_sensors_model_eclipse.get();
 
-  // TODO : Implement a configurable sun sensor model
-  return truth_s;
+  if (model_eclipse) {
+    auto const &truth_r_eci = truth_satellite_orbit_r_eci->get();
+    auto const &truth_s_eci = truth_satellite_environment_s_eci->get();
+
+    if (lin::dot(truth_s_eci, truth_r_eci) < 0.0) {
+      return lin::nans<Vector3>();
+    }
+  }
+
+  /* Currently, we're using noise representation in spherical coordinates.
+   * This is alright for now but has issues when theta is near ninety or
+   * negative ninety degrees.
+   *
+   * TODO: Update the sun sensor model to include individual diodes.
+   */
+  auto const &truth_s_body = truth_satellite_environment_s_body->get();
+  auto const &sigma = sensors_satellite_sun_sensors_s_sigma.get();
+
+  auto const phi = lin::atan2(truth_s_body(1), truth_s_body(0)) +
+                   sigma(0) * _randoms.gaussian();
+  auto const theta = lin::acos(truth_s_body(2) / lin::norm(truth_s_body)) +
+                     sigma(1) * _randoms.gaussian();
+
+  return {lin::sin(theta) * lin::cos(phi), lin::sin(theta) * lin::sin(phi),
+      lin::cos(theta)};
 }
-}  // namespace psim
+
+Vector3 SunSensors::sensors_satellite_sun_sensors_s_error() const {
+  auto const &truth_s = truth_satellite_environment_s_body->get();
+  auto const &s = Super::sensors_satellite_sun_sensors_s.get();
+
+  return s - truth_s;
+}
+} // namespace psim


### PR DESCRIPTION
# Improved Sun Sensors Model

Relates to #143.

### Summary of changes

- Added single spherical angle noise model. This model is currently employed by the filter as well but will have to be updated as the model breaks down when the sun vector is near the z axis.
- Added a simple eclipse model. Note, the model must be enable for it to be active (see config file additions).

### Testing

Some sample images taken with eclipse and without eclipse are included here.

With eclipse enabled:

![eclipse_s](https://user-images.githubusercontent.com/33558436/103845508-358b2900-506a-11eb-98d9-da56a0c31a59.png)
![eclipse_s_error](https://user-images.githubusercontent.com/33558436/103845514-3754ec80-506a-11eb-817f-c8389a216d80.png)

Without eclipse enabled:

![s](https://user-images.githubusercontent.com/33558436/103845573-55225180-506a-11eb-9f44-d6a0cb71fdd7.png)
![s_error](https://user-images.githubusercontent.com/33558436/103845576-56537e80-506a-11eb-994d-c775edc2dd8b.png)

You can also see the more detailed behavior with a shorter time scale:

![short_s](https://user-images.githubusercontent.com/33558436/103845695-8ef35800-506a-11eb-9571-dd8944371a22.png)
![short_s_error](https://user-images.githubusercontent.com/33558436/103845698-90248500-506a-11eb-9833-ad96cc59f2d5.png)

The above plots can be generated with the following command:

    python -m psim -s 20000 -p sensors/sun_sensors -ps 1 -c sensors/base,truth/base,truth/deployment -v SingleAttitudeOrbitGnc
