### PR TITLE
Update reason for disabling the eclipse model

### DIFF
--- a/config/parameters/sensors/base.txt
+++ b/config/parameters/sensors/base.txt
@@ -9,8 +9,9 @@
 # The noise distribution for the sun sensors was chosen as two degrees, one
 # sigma. This matches the attitude filter's settings.
 #
-# Currently, we're not modelling eclipse with the sun sensors due to the
-# attitude estimators questionable performance. This will be updated later.
+# Currently, we're not modelling eclipse with the sun sensors due to GNC
+# assert statements not being tolerant of NaN inputs:
+# https://github.com/pathfinder-for-autonomous-navigation/psim/issues/206.
 #
 
 # Leader spacecraft base sensor configuration


### PR DESCRIPTION
Small comment update. Previous comment ended up being incorrect as the filter behaves well during eclipse.