### PR TITLE
Fix Velocity Transform from ECI to ECEF

### DIFF
--- a/config/plots/truth/orbit.yml
+++ b/config/plots/truth/orbit.yml
@@ -4,8 +4,24 @@
   x: truth.t.s
   y: [truth.leader.orbit.r.eci.x, truth.leader.orbit.r.eci.y, truth.leader.orbit.r.eci.z]
 
-# Plot the 3D trajectory
+# Plot the 3D trajectory in ECI
 - type: Plot3D
   x: truth.leader.orbit.r.eci.x
   y: truth.leader.orbit.r.eci.y
   z: truth.leader.orbit.r.eci.z
+
+# Plot velocity over time in ECI
+- type: Plot2D
+  x: truth.t.s
+  y: [truth.leader.orbit.v.eci.x, truth.leader.orbit.v.eci.y, truth.leader.orbit.v.eci.z]
+
+# Plot the 3D trajectory in ECEF
+- type: Plot3D
+  x: truth.leader.orbit.r.ecef.x
+  y: truth.leader.orbit.r.ecef.y
+  z: truth.leader.orbit.r.ecef.z
+
+# Plot velocity over time in ECEF
+- type: Plot2D
+  x: truth.t.s
+  y: [truth.leader.orbit.v.ecef.x, truth.leader.orbit.v.ecef.y, truth.leader.orbit.v.ecef.z]

--- a/include/psim/truth/transform_velocity.yml
+++ b/include/psim/truth/transform_velocity.yml
@@ -9,7 +9,6 @@ comment: >
 args:
     - satellite
     - vector
-    - frame
 
 adds:
     - name: "{vector}.ecef"
@@ -33,9 +32,9 @@ gets:
       type: Vector4
     - name: "truth.earth.w"
       type: Vector3
-    - name: "truth.{satellite}.orbit.r.{frame}"
+    - name: "truth.{satellite}.orbit.r.ecef"
       type: Vector3
       comment: >
-          The frame of the position vector needs to be explicitly specified here
-          because we need the position of the frame we're transforming from.
-          This implies this model is also dependant on a position transformer.
+          The position of the satellite is required in the ECEF frame in order
+          to account for Earth's rotation. This implies dependance on the
+          position transformer as well.

--- a/src/psim/truth/transform_velocity.cpp
+++ b/src/psim/truth/transform_velocity.cpp
@@ -32,16 +32,16 @@ namespace psim {
 TransformVelocityEcef::TransformVelocityEcef(RandomsGenerator &randoms,
     Configuration const &config, std::string const &satellite,
     std::string const &vector)
-  : Super(randoms, config, satellite, vector, "ecef") { }
+  : Super(randoms, config, satellite, vector) { }
 
 Vector3 TransformVelocityEcef::vector_ecef() const {
   return vector->get();
 }
 
 Vector3 TransformVelocityEcef::vector_eci() const {
-  auto const &r_ecef = truth_satellite_orbit_r_frame->get();
   auto const &v_ecef = vector->get();
   auto const &q_eci_ecef = truth_earth_q_eci_ecef->get();
+  auto const &r_ecef = truth_satellite_orbit_r_ecef->get();
   auto const &w_earth = truth_earth_w->get();
 
   Vector3 v_eci;
@@ -52,17 +52,17 @@ Vector3 TransformVelocityEcef::vector_eci() const {
 TransformVelocityEci::TransformVelocityEci(RandomsGenerator &randoms,
     Configuration const &config, std::string const &satellite,
     std::string const &vector)
-  : Super(randoms, config, satellite, vector, "eci") { }
+  : Super(randoms, config, satellite, vector) { }
 
 Vector3 TransformVelocityEci::vector_ecef() const {
-  auto const &r_eci = truth_satellite_orbit_r_frame->get();
   auto const &v_eci = vector->get();
   auto const &q_ecef_eci = truth_earth_q_ecef_eci->get();
+  auto const &r_ecef = truth_satellite_orbit_r_ecef->get();
   auto const &w_earth = truth_earth_w->get();
 
-  Vector3 v_ecef;
-  gnc::utl::rotate_frame(q_ecef_eci, (v_eci - lin::cross(w_earth, r_eci).eval(), v_ecef));
-  return v_ecef;
+  Vector3 v;
+  gnc::utl::rotate_frame(q_ecef_eci, v_eci, v);
+  return v - lin::cross(w_earth, r_ecef);
 }
 
 Vector3 TransformVelocityEci::vector_eci() const {


### PR DESCRIPTION
### Summary of Changes

* Updated the transform for converting velocities from ECI to ECEF. The angular rate of Earth is always specified in ECEF and there the original transformation was incorrect and `w x r` should always be performed in a frame aligned with ECEF.
* Add more plots to `config/plots/truth/orbit.yml` to show ECEF and ECI telemetry.

### Testing

See the following image below. Before the change, the velocity was reported to be zero.

![truth_v](https://user-images.githubusercontent.com/33558436/105918634-3cbaac80-6002-11eb-873d-e52ad60ac457.png)
