### PR TITLE
Add GPS Velocity Readout

### DIFF
--- a/config/parameters/sensors/base.txt
+++ b/config/parameters/sensors/base.txt
@@ -16,7 +16,8 @@
 
 # Leader spacecraft base sensor configuration
 
-sensors.leader.gps.r.sigma  0.0 0.0 0.0
+sensors.leader.gps.r.sigma  5.0 5.0 5.0
+sensors.leader.gps.v.sigma  5.0 5.0 5.0
 
 sensors.leader.gyroscope.w.bias        0.02    0.01    -0.03
 sensors.leader.gyroscope.w.bias.sigma  1.00e-6 1.00e-6  1.00e-6
@@ -29,7 +30,8 @@ sensors.leader.sun_sensors.s.sigma        0.0349066 0.0349066
 
 # Follower spacecraft base sensor configuration
 
-sensors.follower.gps.r.sigma  0.0 0.0 0.0
+sensors.follower.gps.r.sigma  5.0 5.0 5.0
+sensors.follower.gps.v.sigma  5.0 5.0 5.0
 
 sensors.follower.gyroscope.w.bias        -0.01    0.01    0.04
 sensors.follower.gyroscope.w.bias.sigma   1.00e-6 1.00e-6 1.00e-6

--- a/config/plots/sensors/gps.yml
+++ b/config/plots/sensors/gps.yml
@@ -1,10 +1,20 @@
 
-# GPS measurement over time.
+# GPS position measurement over time.
 - type: Plot2D
   x: truth.t.s
   y: [sensors.leader.gps.r.x, sensors.leader.gps.r.y, sensors.leader.gps.r.z]
 
-# GPS measurement error over time.
+# GPS position measurement error over time.
 - type: Plot2D
   x: truth.t.s
   y: [sensors.leader.gps.r.error.x, sensors.leader.gps.r.error.y, sensors.leader.gps.r.error.z]
+
+# GPS velocity measurement over time.
+- type: Plot2D
+  x: truth.t.s
+  y: [sensors.leader.gps.v.x, sensors.leader.gps.v.y, sensors.leader.gps.v.z]
+
+# GPS velocity measurement error over time.
+- type: Plot2D
+  x: truth.t.s
+  y: [sensors.leader.gps.v.error.x, sensors.leader.gps.v.error.y, sensors.leader.gps.v.error.z]

--- a/include/psim/sensors/gps_no_attitude.hpp
+++ b/include/psim/sensors/gps_no_attitude.hpp
@@ -45,6 +45,8 @@ class GpsNoAttitude : public GpsNoAttitudeInterface<GpsNoAttitude> {
 
   Vector3 sensors_satellite_gps_r() const;
   Vector3 sensors_satellite_gps_r_error() const;
+  Vector3 sensors_satellite_gps_v() const;
+  Vector3 sensors_satellite_gps_v_error() const;
 };
 }  // namespace psim
 

--- a/include/psim/sensors/gps_no_attitude.yml
+++ b/include/psim/sensors/gps_no_attitude.yml
@@ -13,6 +13,10 @@ params:
       type: Vector3
       comment: >
         Standard deviation of the position reading from the GPS.
+    - name: "sensors.{satellite}.gps.v.sigma"
+      type: Vector3
+      comment: >
+        Standard deviation of the velocity reading from the GPS.
 
 adds:
     - name: "sensors.{satellite}.gps.r"
@@ -23,7 +27,17 @@ adds:
       type: Lazy Vector3
       comment: >
           Error in the position reported by the GPS in ECEF.
+    - name: "sensors.{satellite}.gps.v"
+      type: Lazy Vector3
+      comment: >
+          Velocity reported by the GPS in ECEF.
+    - name: "sensors.{satellite}.gps.v.error"
+      type: Lazy Vector3
+      comment: >
+          Error in the velocity reported by the GPS in ECEF.
 
 gets:
     - name: "truth.{satellite}.orbit.r.ecef"
+      type: Vector3
+    - name: "truth.{satellite}.orbit.v.ecef"
       type: Vector3

--- a/src/psim/sensors/gps_no_attitude.cpp
+++ b/src/psim/sensors/gps_no_attitude.cpp
@@ -32,15 +32,27 @@ namespace psim {
 
 Vector3 GpsNoAttitude::sensors_satellite_gps_r() const {
   auto const &truth_r_ecef = truth_satellite_orbit_r_ecef->get();
-  auto const &sigma = sensors_satellite_gps_r_sigma.get();
+  auto const &error = Super::sensors_satellite_gps_r_error.get();
 
-  return truth_r_ecef + lin::multiply(sigma, lin::gaussians<Vector3>(_randoms));
+  return truth_r_ecef + error;
 }
 
 Vector3 GpsNoAttitude::sensors_satellite_gps_r_error() const {
-  auto const &truth_r_ecef = truth_satellite_orbit_r_ecef->get();
-  auto const &sensors_r_ecef = this->Super::sensors_satellite_gps_r.get();
+  auto const &sigma = sensors_satellite_gps_r_sigma.get();
 
-  return sensors_r_ecef - truth_r_ecef;
+  return lin::multiply(sigma, lin::gaussians<Vector3>(_randoms));
+}
+
+Vector3 GpsNoAttitude::sensors_satellite_gps_v() const {
+  auto const &truth_v_ecef = truth_satellite_orbit_v_ecef->get();
+  auto const &error = Super::sensors_satellite_gps_v_error.get();
+
+  return truth_v_ecef + error;
+}
+
+Vector3 GpsNoAttitude::sensors_satellite_gps_v_error() const {
+  auto const &sigma = sensors_satellite_gps_v_sigma.get();
+
+  return lin::multiply(sigma, lin::gaussians<Vector3>(_randoms));
 }
 }  // namespace psim


### PR DESCRIPTION
Testing required #292.

Relates to #142.

### Summary of Changes

* A velocity readout was added to the GPS to better match the sensor on orbit.
* Uncertainties of `5.0 m` and `5.0 m/s` (both one sigma) were added to the position and velocity readouts of the GPS. These values will be updated properly in #296.

### Testing

See the images below generated via the following command:

    python -m psim -s 2000 -p truth/orbit,sensors/gps -ps 1 -c sensors/base,truth/base,truth/deployment -v SingleOrbitGnc

![truth_v](https://user-images.githubusercontent.com/33558436/105918634-3cbaac80-6002-11eb-873d-e52ad60ac457.png)
![gps_v](https://user-images.githubusercontent.com/33558436/105918894-b8b4f480-6002-11eb-92c8-078fcea972d4.png)
![gps_v_err](https://user-images.githubusercontent.com/33558436/105918644-3fb59d00-6002-11eb-995d-2cb132b6b443.png)
