### PR TITLE
Orbit Library Orbit Estimator Implementation

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -21,7 +21,7 @@ cc_library(
         "include/gnc/**/*.inl"
     ]),
     hdrs = glob([
-        "include/gnc/**/*.hpp", "include/orb/*.h", "include/orb/*.hpp"
+        "include/gnc/**/*.hpp", "include/orb/**/*.h", "include/orb/**/*.hpp"
     ]),
     includes = ["include"],
     copts = ["-Isrc", "-fvisibility=hidden"],

--- a/config/plots/fc/orbit.yml
+++ b/config/plots/fc/orbit.yml
@@ -1,0 +1,26 @@
+
+# Orbit estimate's validity over time.
+- type: Plot2D
+  x: truth.t.s
+  y: fc.leader.orbit.is_valid
+
+# Orbit estimator's performance in terms of position and velocity estimate
+# error.
+- type: PlotEstimate
+  x: truth.t.s
+  y: fc.leader.orbit.r.x
+- type: PlotEstimate
+  x: truth.t.s
+  y: fc.leader.orbit.r.y
+- type: PlotEstimate
+  x: truth.t.s
+  y: fc.leader.orbit.r.z
+- type: PlotEstimate
+  x: truth.t.s
+  y: fc.leader.orbit.v.x
+- type: PlotEstimate
+  x: truth.t.s
+  y: fc.leader.orbit.v.y
+- type: PlotEstimate
+  x: truth.t.s
+  y: fc.leader.orbit.v.z

--- a/include/orb/OrbitEstimate.hpp
+++ b/include/orb/OrbitEstimate.hpp
@@ -1,0 +1,256 @@
+/*
+MIT License
+
+Copyright (c) 2020 Pathfinder for Autonomous Navigation (PAN)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+/**
+ * \file OrbitEstimate.hpp
+ * \author Kyle Krol
+ * \date 02 FEB 2021
+ * \brief A class to provide an estimate of a sat's orbit given a GPS position
+ *        and velocity readout.
+ */
+
+#pragma once
+#include <lin/core.hpp>
+#include <lin/factorizations.hpp>
+#include <lin/generators.hpp>
+#include <lin/references.hpp>
+#include <lin/substitutions.hpp>
+#include "Orbit.h"
+
+namespace orb
+{
+
+/** This wrapper around the orb::Orbit class intended to facilitate orbital
+ *  state estimation of a single satellite given GPS data.
+ */
+class OrbitEstimate {
+  public:
+    /// \private
+    /** Current orbital state estimate.
+     */
+    Orbit _orbit;
+
+    /// \private
+    /** Square root of the state covariance matrix (also denoted as S).
+     */
+    lin::Matrixd<6, 6> _sqrtP = lin::nans<lin::Matrixd<6, 6>>();
+
+    /**
+     */
+    int64_t nsgpstime() const{
+        return _orbit.nsgpstime();
+    }
+
+    /** Return position of the sat (m).
+     *
+     *  If the orbit estimate isn't valid, the returned vector will contain
+     *  only nans.
+     */
+    lin::Vector3d recef() const {
+        return _orbit.recef();
+    }
+
+    /** Return velocity of the sat (m).
+     *
+     *  If the orbit estimate isn't valid, the returned vector will contain
+     *  only nans.
+     */
+    lin::Vector3d vecef() const {
+        return _orbit.vecef();
+    }
+
+    /** Return the cholesky factorization of the state covariance matrix.
+     */
+    lin::Matrixd<6, 6> S() const {
+        return _sqrtP;
+    }
+
+    /** Return true if the orbit estimate is valid.
+     *
+     *  See orb::Orbit::valid. An orbit estimate has the additional condition
+     *  that the covariance of the state estimate is finite.
+     */
+    bool valid() const {
+        return _orbit.valid();
+    }
+
+    /// \private
+    /** Helper function to determine if the orbit estimate is valid.
+     */
+    void _check_validity() {
+        _orbit._check_validity();
+        if (!_orbit.valid()) {
+            _sqrtP = lin::nans<lin::Matrixd<6, 6>>();
+        }
+    }
+
+    /** Construct an invalid orbit estimate.
+     */
+    OrbitEstimate() {}
+
+    /** Construct an orbit estimate from time, position, velocity, and an
+     *  initial state covariance.
+     * 
+     *  @param[in] ns_gps_time time since gps epoch (ns).
+     *  @param[in] r_ecef      position of the center of mass of the sat (m).
+     *  @param[in] v_ecef      velocity of the sat (m/s).
+     *  @param[in] S           cholesky factorization of the state estimate
+     *                         covariance.
+     */
+    OrbitEstimate(int64_t const &ns_gps_time,
+                  lin::Vector3d const &r_ecef,
+                  lin::Vector3d const &v_ecef,
+                  lin::Matrixd<6, 6> const &S
+                  ) :
+        _orbit(ns_gps_time, r_ecef, v_ecef), _sqrtP(S) {
+        _check_validity();
+    }
+
+    /** Apply a deltav to the orbit estimate.
+     *
+     *  @param[in] deltav_ecef the change in velocity in the ecef frame (m/s).
+     */
+    void applydeltav(lin::Vector3d const &deltav_ecef) {
+        _orbit.applydeltav(deltav_ecef);
+        // TODO : Update state covariance
+
+        _check_validity();
+    }
+
+    /** Return the specific energy of the orbit estimate (J/kg).
+     * 
+     *  If the orbit estimate is invalid this returns nan.
+     *
+     *  @param[in] earth_rate_ecef Earth's angular rate in the ecef frame
+     *                             (rad/s).
+     */
+    double specifienergy(lin::Vector3d const &earth_rate_ecef) const {
+        return _orbit.specificenergy(earth_rate_ecef);
+    }
+
+    /************* Single Cycle Prediction and Estimation ******************/
+
+    /** Perform a predition step only - i.e. no measurement is accounted for.
+     *
+     *  @param[in]  dt_ns
+     *  @param[in]  earth_rate_ecef
+     *  @param[in]  sqrtQ
+     *  @param[out] specificenergy
+     */
+    void shortupdate(int32_t            const  dt_ns,
+                     lin::Vector3d      const &earth_rate_ecef,
+                     lin::Matrixd<6, 6> const &sqrtQ,
+                     double                   &specificenergy
+                     ) {
+        lin::Matrixd<6, 6> F;
+        _orbit.shortupdate(dt_ns, earth_rate_ecef, specificenergy, F);
+
+        /* This leverages the square root formulation of the EKF covariance
+         * prediction step:
+         *
+         *   qr([ S_k|k transpose(F_k) ]) = _ S_k+1|k
+         *     ([       sqrt(Q_k)      ])
+         */
+        lin::Matrixd<12, 6> A, _;
+        lin::ref<lin::Matrixd<6, 6>>(A, 0, 0) = _sqrtP * lin::transpose(F);
+        lin::ref<lin::Matrixd<6, 6>>(A, 6, 0) = sqrtQ;
+        lin::qr(A, _, _sqrtP);
+
+        _check_validity();
+    }
+
+    /** Perform a predition step only - i.e. no measurement is accounted for.
+     *
+     *  @param[in]  dt_ns
+     *  @param[in]  earth_rate_ecef
+     *  @param[in]  sqrtQ
+     *  @param[out] specificenergy
+     */
+    void shortupdate(int32_t            const  dt_ns,
+                     lin::Vector3d      const &earth_rate_ecef,
+                     lin::Vector3d      const &r_ecef,
+                     lin::Vector3d      const &v_ecef,
+                     lin::Matrixd<6, 6> const &sqrtQ,
+                     lin::Matrixd<6, 6> const &sqrtR,
+                     double                   &specificenergy
+                     ) {
+        // Prediction step
+        {
+            double _;
+            shortupdate(dt_ns, earth_rate_ecef, sqrtQ, _);
+        }
+
+        // Update step
+        {
+            /* This again leverages the square root formulation of the EKF. The
+             * update step is given by:
+             * 
+             *   qr([      sqrt(R)             0    ]) = _ [ transpose(C)      D     ]
+             *     ([ S_k+1|k transpose(H)  S_k+1|k ])     [      0        S_k+1|k+1 ]
+             */
+            lin::Matrixd<12, 12> A, B, _;
+            lin::ref<lin::Matrixd<6, 6>>(A, 0, 0) = sqrtR;
+            lin::ref<lin::Matrixd<6, 6>>(A, 0, 6) = lin::zeros<lin::Matrixd<6, 6>>();
+            lin::ref<lin::Matrixd<6, 6>>(A, 6, 0) = _sqrtP;  // H = I
+            lin::ref<lin::Matrixd<6, 6>>(A, 6, 6) = _sqrtP;
+            lin::qr(A, _, B);
+
+            lin::Matrixd<6, 6> C, D;
+            C = lin::transpose(lin::ref<lin::Matrixd<6, 6>>(B, 0, 0));
+            D = lin::ref<lin::Matrixd<6, 6>>(B, 0, 6);
+
+            /* Kalman gain calculation from the square root formulation:
+             *
+             *   K_k+1 = D inverse(C)
+             */
+            lin::Matrixd<6, 6> K;
+            {
+                lin::Matrixd<6, 6> Q, R;
+                lin::qr(lin::transpose(C).eval(), Q, R);
+                lin::backward_sub(R, K, (lin::transpose(Q) * lin::transpose(D)).eval());
+
+                K = lin::transpose(K).eval();
+            }
+
+            // Measurement
+            lin::Vectord<6> z;
+            lin::ref<lin::Vector3d>(z, 0, 0) = r_ecef;
+            lin::ref<lin::Vector3d>(z, 3, 0) = v_ecef;
+
+            lin::Vectord<6> x;
+            auto r = lin::ref<lin::Vector3d>(x, 0, 0);
+            auto v = lin::ref<lin::Vector3d>(x, 3, 0);
+
+            r = _orbit.recef();
+            v = _orbit.vecef();
+            x = x + K * (z - x).eval();
+
+            _orbit = Orbit(_orbit.nsgpstime(), r, v);
+            _sqrtP = lin::ref<lin::Matrixd<6, 6>>(B, 6, 6);
+
+            _check_validity();
+        }
+    }
+};
+} // namespace orb

--- a/include/orb/OrbitEstimate.hpp
+++ b/include/orb/OrbitEstimate.hpp
@@ -216,22 +216,15 @@ class OrbitEstimate {
             lin::ref<lin::Matrixd<6, 6>>(A, 6, 6) = _sqrtP;
             lin::qr(A, _, B);
 
-            lin::Matrixd<6, 6> C, D;
-            C = lin::transpose(lin::ref<lin::Matrixd<6, 6>>(B, 0, 0));
-            D = lin::ref<lin::Matrixd<6, 6>>(B, 0, 6);
-
             /* Kalman gain calculation from the square root formulation:
              *
-             *   K_k+1 = D inverse(C)
+             *   K_k+1 = transpose(D) inverse(C)
+             * 
+             * where C is already upper triangular.
              */
             lin::Matrixd<6, 6> K;
-            {
-                lin::Matrixd<6, 6> Q, R;
-                lin::qr(lin::transpose(C).eval(), Q, R);
-                lin::backward_sub(R, K, (lin::transpose(Q) * lin::transpose(D)).eval());
-
-                K = lin::transpose(K).eval();
-            }
+            lin::forward_sub(lin::ref<lin::Matrixd<6, 6>>(B, 0, 0), K, lin::ref<lin::Matrixd<6, 6>>(B, 0, 6));
+            K = lin::transpose(K).eval();
 
             // Measurement
             lin::Vectord<6> z;

--- a/include/psim/fc/orbit_estimator.hpp
+++ b/include/psim/fc/orbit_estimator.hpp
@@ -1,0 +1,62 @@
+//
+// MIT License
+//
+// Copyright (c) 2020 Pathfinder for Autonomous Navigation (PAN)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+/** @file psim/fc/orbit_estimator.hpp
+ *  @author Kyle Krol
+ */
+
+#ifndef PSIM_FC_ORBIT_ESTIMATOR_HPP_
+#define PSIM_FC_ORBIT_ESTIMATOR_HPP_
+
+#include <psim/fc/orbit_estimator.yml.hpp>
+
+#include <orb/OrbitEstimate.hpp>
+
+namespace psim {
+
+class OrbOrbitEstimator : public OrbitEstimatorInterface<OrbOrbitEstimator> {
+ private:
+  typedef OrbitEstimatorInterface<OrbOrbitEstimator> Super;
+
+  orb::OrbitEstimate estimate;
+
+  void _set_orbit_outputs();
+
+ public:
+  using Super::OrbitEstimatorInterface;
+
+  OrbOrbitEstimator() = delete;
+  virtual ~OrbOrbitEstimator() = default;
+
+  virtual void add_fields(State &state) override;
+  virtual void step() override;
+
+  Vector3 fc_satellite_orbit_r_error() const;
+  Vector3 fc_satellite_orbit_r_sigma() const;
+  Vector3 fc_satellite_orbit_v_error() const;
+  Vector3 fc_satellite_orbit_v_sigma() const;
+};
+} // namespace psim
+
+#endif

--- a/include/psim/fc/orbit_estimator.yml
+++ b/include/psim/fc/orbit_estimator.yml
@@ -1,0 +1,54 @@
+
+name: OrbitEstimatorInterface
+type: Model
+comment: >
+    Interface for how the flight computer's orbit estimator will interact with
+    simulation in PSim standalone.
+
+args:
+    - satellite
+
+adds:
+    - name: "fc.{satellite}.orbit.is_valid"
+      type: Integer
+      comment: >
+        Flag specifying whether or not the estimate is currently valid. Zero
+        indicates the estimate isn't valid while one indicates it is.
+    - name: "fc.{satellite}.orbit.r"
+      type: Vector3
+      comment: >
+        Current position estimate in ECEF.
+    - name: "fc.{satellite}.orbit.r.error"
+      type: Lazy Vector3
+      comment: >
+        Current position estimate error.
+    - name: "fc.{satellite}.orbit.r.sigma"
+      type: Lazy Vector3
+      comment: >
+        One sigma bounds on the current position estimate error.
+    - name: "fc.{satellite}.orbit.v"
+      type: Vector3
+      comment: >
+        Current velocity estimate in ECEF.
+    - name: "fc.{satellite}.orbit.v.error"
+      type: Lazy Vector3
+      comment: >
+        Current velocity estimate error.
+    - name: "fc.{satellite}.orbit.v.sigma"
+      type: Lazy Vector3
+      comment: >
+        One sigma bounds on the current velocity estimate error.
+
+gets:
+    - name: "truth.t.s"
+      type: Real
+    - name: "truth.dt.ns"
+      type: Integer
+    - name: "truth.{satellite}.orbit.r.ecef"
+      type: Vector3
+    - name: "truth.{satellite}.orbit.v.ecef"
+      type: Vector3
+    - name: "sensors.{satellite}.gps.r"
+      type: Vector3
+    - name: "sensors.{satellite}.gps.v"
+      type: Vector3

--- a/include/psim/simulations/orbit_estimator_test.hpp
+++ b/include/psim/simulations/orbit_estimator_test.hpp
@@ -1,0 +1,50 @@
+//
+// MIT License
+//
+// Copyright (c) 2020 Pathfinder for Autonomous Navigation (PAN)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+/** @file psim/simulation/orbit_estimator_test.hpp
+ *  @author Kyle Krol
+ */
+
+#ifndef PSIM_SIMULATIONS_ORBIT_ESTIMATOR_TEST_HPP_
+#define PSIM_SIMULATIONS_ORBIT_ESTIMATOR_TEST_HPP_
+
+#include <psim/core/configuration.hpp>
+#include <psim/core/model_list.hpp>
+
+namespace psim {
+
+/** @brief Models orbital dynamics of a single spacecraft in order to test the
+ *         orbit estimator.
+ */
+class OrbOrbitEstimatorTest : public ModelList {
+ public:
+  OrbOrbitEstimatorTest() = delete;
+  virtual ~OrbOrbitEstimatorTest() = default;
+
+  OrbOrbitEstimatorTest(
+      RandomsGenerator &randoms, Configuration const &config);
+};
+} // namespace psim
+
+#endif

--- a/python/psim/_psim.cpp
+++ b/python/psim/_psim.cpp
@@ -37,6 +37,7 @@
 #include <psim/simulations/attitude_estimator_test.hpp>
 #include <psim/simulations/dual_attitude_orbit.hpp>
 #include <psim/simulations/dual_orbit.hpp>
+#include <psim/simulations/orbit_estimator_test.hpp>
 #include <psim/simulations/single_attitude_orbit.hpp>
 #include <psim/simulations/single_orbit.hpp>
 
@@ -188,6 +189,7 @@ void py_simulation(py::module &m) {
   PY_SIMULATION(AttitudeEstimatorTestGnc);
   PY_SIMULATION(SingleAttitudeOrbitGnc);
   PY_SIMULATION(SingleOrbitGnc);
+  PY_SIMULATION(OrbOrbitEstimatorTest);
   PY_SIMULATION(DualAttitudeOrbitGnc);
   PY_SIMULATION(DualOrbitGnc);
 }

--- a/python/psim/sims.py
+++ b/python/psim/sims.py
@@ -5,6 +5,7 @@ from _psim import (
     AttitudeEstimatorTestGnc,
     DualAttitudeOrbitGnc,
     DualOrbitGnc,
+    OrbOrbitEstimatorTest,
     SingleAttitudeOrbitGnc,
     SingleOrbitGnc,
 )

--- a/src/psim/fc/orbit_estimator.cpp
+++ b/src/psim/fc/orbit_estimator.cpp
@@ -1,0 +1,104 @@
+//
+// MIT License
+//
+// Copyright (c) 2020 Pathfinder for Autonomous Navigation (PAN)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+/** @file psim/fc/orbit_estimator.cpp
+ *  @author Kyle Krol
+ */
+
+#include <psim/fc/orbit_estimator.hpp>
+
+#include <gnc/environment.hpp>
+
+#include <lin/core.hpp>
+#include <lin/generators.hpp>
+#include <lin/math.hpp>
+#include <lin/queries.hpp>
+
+namespace psim {
+
+void OrbOrbitEstimator::_set_orbit_outputs() {
+  fc_satellite_orbit_is_valid.get() = estimate.valid();
+  fc_satellite_orbit_r.get() = estimate.recef();
+  fc_satellite_orbit_v.get() = estimate.vecef();
+}
+
+void OrbOrbitEstimator::add_fields(State &state) {
+  this->Super::add_fields(state);
+
+  // This ensures upon simulation construction the state fields hold proper
+  // values.
+  _set_orbit_outputs();
+}
+
+void OrbOrbitEstimator::step() {
+  this->Super::step();
+
+  constexpr auto sqrtQ = lin::diag(lin::consts<Vector<6>>(0.1)).eval();
+  constexpr auto sqrtR = lin::diag(lin::consts<Vector<6>>(5.0)).eval();
+
+  auto const &t = truth_t_s->get();
+  auto const &dt = truth_dt_ns->get();
+  auto const &r = sensors_satellite_gps_r->get();
+  auto const &v = sensors_satellite_gps_v->get();
+
+  Vector3 w;
+  gnc::env::earth_angular_rate(t, w);
+
+  if (estimate.valid()) {
+    double _;
+    if (lin::all(lin::isfinite(r)) && lin::all(lin::isfinite(v)))
+      estimate.shortupdate(dt, w, r, v, sqrtQ, sqrtR, _);
+    else
+      estimate.shortupdate(dt, w, sqrtQ, _);
+  }
+  else {
+    if (lin::all(lin::isfinite(r)) && lin::all(lin::isfinite(v)))
+      estimate = orb::OrbitEstimate(orb::MINGPSTIME_NS, r, v, sqrtR);
+  }
+
+  _set_orbit_outputs();
+}
+
+Vector3 OrbOrbitEstimator::fc_satellite_orbit_r_error() const {
+  auto const &r = Super::fc_satellite_orbit_r.get();
+  auto const &truth_r = truth_satellite_orbit_r_ecef->get();
+
+  return r - truth_r;
+}
+
+Vector3 OrbOrbitEstimator::fc_satellite_orbit_r_sigma() const {
+  return lin::ref<Vector3>(lin::diag(estimate.S()), 0, 0);
+}
+
+Vector3 OrbOrbitEstimator::fc_satellite_orbit_v_error() const {
+  auto const &v = Super::fc_satellite_orbit_v.get();
+  auto const &truth_v = truth_satellite_orbit_v_ecef->get();
+
+  return v - truth_v;
+}
+
+Vector3 OrbOrbitEstimator::fc_satellite_orbit_v_sigma() const {
+  return lin::ref<Vector3>(lin::diag(estimate.S()), 3, 0);
+}
+} // namespace psim

--- a/src/psim/simulations/orbit_estimator_test.cpp
+++ b/src/psim/simulations/orbit_estimator_test.cpp
@@ -1,0 +1,42 @@
+//
+// MIT License
+//
+// Copyright (c) 2020 Pathfinder for Autonomous Navigation (PAN)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+/** @file psim/simulations/orbit_estimator_test.cpp
+ *  @author Kyle Krol
+ */
+
+#include <psim/simulations/orbit_estimator_test.hpp>
+
+#include <psim/fc/orbit_estimator.hpp>
+#include <psim/simulations/single_orbit.hpp>
+
+namespace psim {
+
+OrbOrbitEstimatorTest::OrbOrbitEstimatorTest(
+    RandomsGenerator &randoms, Configuration const &config)
+  : ModelList(randoms) {
+  add<SingleOrbitGnc>(randoms, config);
+  add<OrbOrbitEstimator>(randoms, config, "leader");
+}
+} // namespace psim


### PR DESCRIPTION
Closes #78.

### Summary of changes

- Small tweaks to the `//:gnc` target to avoid loosing headers in nested directories within `include/orb/`.
- Square root extended Kalman filter orbital state estimator implementation. GPS position and velocity readouts are taken as sensor measurements in ECEF.
- Flight computer orbit estimator model for `psim` with plots config included.
- Simple orbit estimator simulation for testing in `psim` standalone.

### Testing

See the following plots generate below showing valid estimates of position and velocity over time. Tests were run with the following command:

    python -m psim -s 10000 -p fc/orbit,sensors/gps -ps 1 -c sensors/base,truth/base,truth/deployment -v OrbOrbitEstimatorTest

![rx](https://user-images.githubusercontent.com/33558436/106687129-8d4d7f00-6599-11eb-8377-4071e4d5cc33.png)
![ry](https://user-images.githubusercontent.com/33558436/106687133-8de61580-6599-11eb-9d4d-741311ca25ec.png)
![rz](https://user-images.githubusercontent.com/33558436/106687134-8de61580-6599-11eb-9c07-36d49eafe553.png)
![vx](https://user-images.githubusercontent.com/33558436/106687135-8de61580-6599-11eb-99a0-3f4c82028415.png)
![vy](https://user-images.githubusercontent.com/33558436/106687136-8de61580-6599-11eb-9aa2-7800f3572a7d.png)
![vz](https://user-images.githubusercontent.com/33558436/106687138-8de61580-6599-11eb-8416-d0a024e972b6.png)
