### PR TITLE
CDGPS Sensor Model

### DIFF
--- a/config/parameters/sensors/base.txt
+++ b/config/parameters/sensors/base.txt
@@ -19,6 +19,10 @@
 sensors.leader.gps.r.sigma  5.0 5.0 5.0
 sensors.leader.gps.v.sigma  5.0 5.0 5.0
 
+sensors.leader.cdgps.model_range  1
+sensors.leader.cdgps.range        2000.0
+sensors.leader.cdgps.dr.sigma     0.1    0.1 0.1
+
 sensors.leader.gyroscope.w.bias        0.02    0.01    -0.03
 sensors.leader.gyroscope.w.bias.sigma  1.00e-6 1.00e-6  1.00e-6
 sensors.leader.gyroscope.w.sigma       2.75e-4 2.75e-4  2.75e-4
@@ -32,6 +36,10 @@ sensors.leader.sun_sensors.s.sigma        0.0349066 0.0349066
 
 sensors.follower.gps.r.sigma  5.0 5.0 5.0
 sensors.follower.gps.v.sigma  5.0 5.0 5.0
+
+sensors.follower.cdgps.model_range  1
+sensors.follower.cdgps.range        2000.0
+sensors.follower.cdgps.dr.sigma     0.1    0.1 0.1
 
 sensors.follower.gyroscope.w.bias        -0.01    0.01    0.04
 sensors.follower.gyroscope.w.bias.sigma   1.00e-6 1.00e-6 1.00e-6

--- a/config/plots/sensors/cdgps.yml
+++ b/config/plots/sensors/cdgps.yml
@@ -1,0 +1,10 @@
+
+# CDGPS relative position measurement over time.
+- type: Plot2D
+  x: truth.t.s
+  y: [sensors.leader.cdgps.dr.x, sensors.leader.cdgps.dr.y, sensors.leader.cdgps.dr.z]
+
+# CDGPS relative position measurement error over time.
+- type: Plot2D
+  x: truth.t.s
+  y: [sensors.leader.cdgps.dr.error.x, sensors.leader.cdgps.dr.error.y, sensors.leader.cdgps.dr.error.z]

--- a/include/psim/sensors/cdgps_no_attitude.hpp
+++ b/include/psim/sensors/cdgps_no_attitude.hpp
@@ -1,0 +1,52 @@
+//
+// MIT License
+//
+// Copyright (c) 2020 Pathfinder for Autonomous Navigation (PAN)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+/** @file psim/sensors/cdgps_no_attitude.hpp
+ *  @author Kyle Krol
+ */
+
+#ifndef PSIM_SENSORS_CDGPS_NO_ATTITUDE_HPP_
+#define PSIM_SENSORS_CDGPS_NO_ATTITUDE_HPP_
+
+#include <psim/sensors/cdgps_no_attitude.yml.hpp>
+
+namespace psim {
+
+class CdgpsNoAttitude : public CdgpsNoAttitudeInterface<CdgpsNoAttitude> {
+ private:
+  typedef CdgpsNoAttitudeInterface<CdgpsNoAttitude> Super;
+
+ public:
+  using Super::CdgpsNoAttitudeInterface;
+
+  CdgpsNoAttitude() = delete;
+  virtual ~CdgpsNoAttitude() = default;
+
+  Integer sensors_satellite_cdgps_active() const;
+  Vector3 sensors_satellite_cdgps_dr() const;
+  Vector3 sensors_satellite_cdgps_dr_error() const;
+};
+}  // namespace psim
+
+#endif

--- a/include/psim/sensors/cdgps_no_attitude.yml
+++ b/include/psim/sensors/cdgps_no_attitude.yml
@@ -34,12 +34,13 @@ adds:
     - name: "sensors.{satellite}.cdgps.dr"
       type: Lazy Vector3
       comment: >
-          Relative position of the other satellite reported by the CDGPS in ECEF.
+          Relative position this satellite to the other reported by the CDGPS in
+          ECEF.
     - name: "sensors.{satellite}.cdgps.dr.error"
       type: Lazy Vector3
       comment: >
-          Error in the relative position of the other satellite by the CDGPS in
-          ECEF.
+          Error in the relative position of the this satellite to the other
+          satellite by the CDGPS in ECEF.
 
 gets:
     - name: "truth.{satellite}.orbit.r.ecef"

--- a/include/psim/sensors/cdgps_no_attitude.yml
+++ b/include/psim/sensors/cdgps_no_attitude.yml
@@ -1,0 +1,48 @@
+
+name: CdgpsNoAttitudeInterface
+type: Model
+comment: >
+    Interface for a model responsible for simulating the measurements seen by
+    the CDGPS sensor during flight.
+
+args:
+    - satellite
+    - other
+
+params:
+    - name: "sensors.{satellite}.cdgps.model_range"
+      type: Integer
+      comment: >
+          Flag toggling whether or not being out of range will prevent the CDGPS
+          from producing a reading.
+    - name: "sensors.{satellite}.cdgps.range"
+      type: Real
+      comment: >
+          Range within the CDGPS can still provide readings of the other
+          satellite's position.
+    - name: "sensors.{satellite}.cdgps.dr.sigma"
+      type: Vector3
+      comment: >
+          Standard deviation of the relative position reading from the CDGPS.
+
+adds:
+    - name: "sensors.{satellite}.cdgps.active"
+      type: Lazy Integer
+      comment: >
+          Flag specifying whether or not the CDGPS sensor is currently active
+          and producing readings.
+    - name: "sensors.{satellite}.cdgps.dr"
+      type: Lazy Vector3
+      comment: >
+          Relative position of the other satellite reported by the CDGPS in ECEF.
+    - name: "sensors.{satellite}.cdgps.dr.error"
+      type: Lazy Vector3
+      comment: >
+          Error in the relative position of the other satellite by the CDGPS in
+          ECEF.
+
+gets:
+    - name: "truth.{satellite}.orbit.r.ecef"
+      type: Vector3
+    - name: "truth.{other}.orbit.r.ecef"
+      type: Vector3

--- a/src/psim/sensors/cdgps_no_attitude.cpp
+++ b/src/psim/sensors/cdgps_no_attitude.cpp
@@ -61,7 +61,7 @@ Vector3 CdgpsNoAttitude::sensors_satellite_cdgps_dr() const {
   /** If the sensor isn't active, the NaNs from the error field will make this
    *  calculation results in NaNs as well as desired.
    */
-  return (truth_other_r_ecef - truth_r_ecef) + error;
+  return (truth_r_ecef - truth_other_r_ecef) + error;
 }
 
 Vector3 CdgpsNoAttitude::sensors_satellite_cdgps_dr_error() const {

--- a/src/psim/sensors/cdgps_no_attitude.cpp
+++ b/src/psim/sensors/cdgps_no_attitude.cpp
@@ -1,0 +1,80 @@
+//
+// MIT License
+//
+// Copyright (c) 2020 Pathfinder for Autonomous Navigation (PAN)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+/** @file psim/sensors/cdgps_no_attitude.cpp
+ *  @author Kyle Krol
+ */
+
+#include <psim/sensors/cdgps_no_attitude.hpp>
+
+#include <lin/core.hpp>
+#include <lin/generators.hpp>
+
+namespace psim {
+
+Integer CdgpsNoAttitude::sensors_satellite_cdgps_active() const {
+  auto const &model_range = sensors_satellite_cdgps_model_range.get();
+
+  /* If model range if requested. Otherwise, the sensor will be active all the
+   * time.
+   */
+  if (!model_range) {
+    return true;
+  }
+
+  auto const &range = sensors_satellite_cdgps_range.get();
+  auto const &truth_r_ecef = truth_satellite_orbit_r_ecef->get();
+  auto const &truth_other_r_ecef = truth_other_orbit_r_ecef->get();
+
+  /* The sensor will be active if within range for this timestep. We're using
+   * lin::fro instaed of lin::norm here to avoid a square root.
+   */
+  return lin::fro(truth_other_r_ecef - truth_r_ecef) < (range * range);
+}
+
+Vector3 CdgpsNoAttitude::sensors_satellite_cdgps_dr() const {
+  auto const &truth_r_ecef = truth_satellite_orbit_r_ecef->get();
+  auto const &truth_other_r_ecef = truth_other_orbit_r_ecef->get();
+  auto const &error = Super::sensors_satellite_cdgps_dr_error.get();
+
+  /** If the sensor isn't active, the NaNs from the error field will make this
+   *  calculation results in NaNs as well as desired.
+   */
+  return (truth_other_r_ecef - truth_r_ecef) + error;
+}
+
+Vector3 CdgpsNoAttitude::sensors_satellite_cdgps_dr_error() const {
+  auto const &active = Super::sensors_satellite_cdgps_active.get();
+
+  /* Only calculate an output if the sensor is active.
+   */
+  if (active) {
+    auto const &sigma = sensors_satellite_cdgps_dr_sigma.get();
+
+    return lin::multiply(sigma, lin::gaussians<Vector3>(_randoms));
+  }
+
+  return lin::nans<Vector3>();
+}
+}  // namespace psim

--- a/src/psim/simulations/dual_attitude_orbit.cpp
+++ b/src/psim/simulations/dual_attitude_orbit.cpp
@@ -28,6 +28,7 @@
 
 #include <psim/simulations/dual_attitude_orbit.hpp>
 
+#include <psim/sensors/cdgps_no_attitude.hpp>
 #include <psim/sensors/satellite_sensors.hpp>
 #include <psim/truth/earth.hpp>
 #include <psim/truth/hill_frame.hpp>
@@ -49,5 +50,7 @@ DualAttitudeOrbitGnc::DualAttitudeOrbitGnc(
   // Sensors model
   add<SatelliteSensors>(randoms, config, "leader");
   add<SatelliteSensors>(randoms, config, "follower");
+  add<CdgpsNoAttitude>(randoms, config, "leader", "follower");
+  add<CdgpsNoAttitude>(randoms, config, "follower", "leader");
 }
 } // namespace psim

--- a/src/psim/simulations/dual_orbit.cpp
+++ b/src/psim/simulations/dual_orbit.cpp
@@ -28,6 +28,7 @@
 
 #include <psim/simulations/dual_orbit.hpp>
 
+#include <psim/sensors/cdgps_no_attitude.hpp>
 #include <psim/sensors/satellite_sensors.hpp>
 #include <psim/truth/earth.hpp>
 #include <psim/truth/hill_frame.hpp>
@@ -49,5 +50,7 @@ DualOrbitGnc::DualOrbitGnc(
   // Sensors model
   add<SatelliteSensorsNoAttitude>(randoms, config, "leader");
   add<SatelliteSensorsNoAttitude>(randoms, config, "follower");
+  add<CdgpsNoAttitude>(randoms, config, "leader", "follower");
+  add<CdgpsNoAttitude>(randoms, config, "follower", "leader");
 }
 } // namespace psim


### PR DESCRIPTION

Relates to #141.

### Summary of changes
- Simple range based CDGPS sensor with additive gaussian noise.
- Sensor plotting files.
- Updated default PSim configurations.
- Added CDGPS sensors to all dual cases.

### Testing

The CDGPS sensor model was tested using deployment initial conditions to verify the range based sensor behavior:

    python -m psim -s 60000 -p sensors/cdgps,sensors/gps -ps 10 -c sensors/base,truth/base,truth/deployment -v DualOrbitGnc

Notice how a little over 8000 seconds in the CDGPS sensor readings disappear where as GPS readings don't; this means the sensor was deactivate at longer ranges as expected.

![cdgps](https://user-images.githubusercontent.com/33558436/107136967-e38e2b00-68d5-11eb-8549-ef5e1ef708f9.png)
![cdgps_error](https://user-images.githubusercontent.com/33558436/107136968-e557ee80-68d5-11eb-9fec-c35ae2a5ffa7.png)
![gps](https://user-images.githubusercontent.com/33558436/107136969-e6891b80-68d5-11eb-8f1a-35335179e225.png)
