### PR TITLE
Add Time Derivative of Earth's Angular Rate to Ephemeris Model

### DIFF
--- a/include/psim/truth/earth.hpp
+++ b/include/psim/truth/earth.hpp
@@ -51,6 +51,7 @@ class EarthGnc : public Earth<EarthGnc> {
   Vector4 truth_earth_q_ecef_eci() const;
   Vector4 truth_earth_q_eci_ecef() const;
   Vector3 truth_earth_w() const;
+  Vector3 truth_earth_w_dot() const;
 };
 }  // namespace psim
 

--- a/include/psim/truth/earth.yml
+++ b/include/psim/truth/earth.yml
@@ -18,7 +18,12 @@ adds:
     - name: "truth.earth.w"
       type: Lazy Vector3
       comment: >
-          Angular rate of Earth (i.e. also the angular rate of the ECEF frame).
+          Angular rate of Earth in ECEF (i.e. also the angular rate of the ECEF
+          frame).
+    - name: "truth.earth.w_dot"
+      type: Lazy Vector3
+      comment: >
+          Time derivative of the angular rate of Earth in ECEF.
 
 gets:
     - name: "truth.t.s"

--- a/src/psim/truth/earth.cpp
+++ b/src/psim/truth/earth.cpp
@@ -31,6 +31,9 @@
 #include <gnc/environment.hpp>
 #include <gnc/utilities.hpp>
 
+#include <lin/core.hpp>
+#include <lin/generators.hpp>
+
 namespace psim {
 
 Vector4 EarthGnc::truth_earth_q_ecef_eci() const {
@@ -55,5 +58,9 @@ Vector3 EarthGnc::truth_earth_w() const {
   Vector3 w_earth;
   gnc::env::earth_angular_rate(t, w_earth);
   return w_earth;
+}
+
+Vector3 EarthGnc::truth_earth_w_dot() const {
+  return lin::zeros<Vector3>();
 }
 }  // namespace psim


### PR DESCRIPTION

### Summary of Changes

- Added an `truth.earth.w_dot` output to the Earth ephemeris model interface.
- Set `truth.earth.w_dot` to zeros in the new implementation.

Note: This serves no purpose now but I'm adding it in now in the event that the orbit propagator is rewritten in ECEF (which is likely going forward).