### PR TITLE
Update Orbit Propagator in Attitude Orbit

### DIFF
--- a/config/plots/truth/attitude.yml
+++ b/config/plots/truth/attitude.yml
@@ -24,3 +24,11 @@
 - type: Plot2D
   x: truth.t.s
   y: truth.leader.attitude.q.body_eci.norm
+
+# Projected area along the direction of travel.
+#
+# This is technically a part of the orbit model but only calculated explicitly
+# while attitude dynamics are being simulation as well.
+- type: Plot2D
+  x: truth.t.s
+  y: truth.leader.orbit.S

--- a/config/plots/truth/orbit.yml
+++ b/config/plots/truth/orbit.yml
@@ -25,3 +25,8 @@
 - type: Plot2D
   x: truth.t.s
   y: [truth.leader.orbit.v.ecef.x, truth.leader.orbit.v.ecef.y, truth.leader.orbit.v.ecef.z]
+
+# Plot orbital energies
+- type: Plot2D
+  x: truth.t.s
+  y: [truth.leader.orbit.T, truth.leader.orbit.U, truth.leader.orbit.E]

--- a/include/psim/truth/attitude_orbit.hpp
+++ b/include/psim/truth/attitude_orbit.hpp
@@ -38,8 +38,7 @@ namespace psim {
 /** @brief Simulates attitude dynamics without fuel slosh and propagates the
  *         orbital state with a Keplerian model in ECI.
  */
-class AttitudeOrbitNoFuelEcef
-  : public AttitudeOrbit<AttitudeOrbitNoFuelEcef> {
+class AttitudeOrbitNoFuelEcef : public AttitudeOrbit<AttitudeOrbitNoFuelEcef> {
  private:
   typedef AttitudeOrbit<AttitudeOrbitNoFuelEcef> Super;
   gnc::Ode4<Real, 16> ode;

--- a/include/psim/truth/attitude_orbit.yml
+++ b/include/psim/truth/attitude_orbit.yml
@@ -31,6 +31,11 @@ params:
           radians per second.
 
 adds:
+    - name: "truth.{satellite}.orbit.S"
+      type: Real
+      comment: >
+          Projected area of the satellite along the direction of travel in
+          meters squared. This value is used for the drag calculation.
     - name: "truth.{satellite}.orbit.r"
       type: Initialized Vector3
       comment: >

--- a/include/psim/truth/attitude_orbit.yml
+++ b/include/psim/truth/attitude_orbit.yml
@@ -48,6 +48,19 @@ adds:
           kilogram meters per second squared. The coordinate system is
           implementation dependant. Note that this field is zeroed out on each
           simulation step to avoid applying a continuous input.
+    - name: "truth.{satellite}.orbit.T"
+      type: Lazy Real
+      comment: >
+          Satellite's orbital kinetic energy.
+    - name: "truth.{satellite}.orbit.U"
+      type: Lazy Real
+      comment: >
+          Satellite's orbital potential energy.
+    - name: "truth.{satellite}.orbit.E"
+      type: Lazy Real
+      comment: >
+          Satellite's orbital total energy. This is essentially the difference
+          of the kinetic and potential energies.
     - name: "truth.{satellite}.attitude.q.body_eci"
       type: Initialized Vector4
       comment: >
@@ -81,11 +94,13 @@ adds:
           Angular momentum of the spacecraft in the body frame.
 
 gets:
-    - name: "truth.t.s"
-      type: Real
     - name: "truth.dt.s"
       type: Real
+    - name: "truth.earth.w"
+      type: Vector3
+    - name: "truth.earth.w_dot"
+      type: Vector3
     - name: "truth.earth.q.eci_ecef"
       type: Vector4
-    - name: "truth.{satellite}.environment.b.body"
+    - name: "truth.{satellite}.environment.b.eci"
       type: Vector3

--- a/src/psim/truth/attitude_utilities.cpp
+++ b/src/psim/truth/attitude_utilities.cpp
@@ -39,13 +39,13 @@ namespace attitude {
 
 Real S(Vector4 const &q_body_eci, Vector4 const &q_eci_ecef,
     Vector3 const &v_ecef) {
-  static constexpr Vector3 PSIM_AREA_VEC = {0.03, 0.03, 0.01};
+  static constexpr Vector3 A = {0.03, 0.03, 0.01};
 
   Vector3 v_body;
   gnc::utl::rotate_frame(q_eci_ecef, v_ecef, v_body);
   gnc::utl::rotate_frame(q_body_eci, v_body);
 
-  return lin::dot(lin::abs(v_body / lin::norm(v_body)), PSIM_AREA_VEC);
+  return lin::dot(lin::abs(v_body / lin::norm(v_body)), A);
 }
 } // namespace attitude
 } // namespace psim

--- a/src/psim/truth/attitude_utilities.cpp
+++ b/src/psim/truth/attitude_utilities.cpp
@@ -22,45 +22,30 @@
 // SOFTWARE.
 //
 
-/** @file psim/truth/attitude_orbit.hpp
+/** @file psim/truth/attitude_utilities.cpp
  *  @author Kyle Krol
  */
 
-#ifndef PSIM_TRUTH_ATTITUDE_ORBIT_HPP_
-#define PSIM_TRUTH_ATTITUDE_ORBIT_HPP_
+#include <psim/truth/attitude_utilities.hpp>
 
-#include <psim/truth/attitude_orbit.yml.hpp>
+#include <gnc/config.hpp>
+#include <gnc/utilities.hpp>
 
-#include <gnc/ode4.hpp>
+#include <lin/core.hpp>
+#include <lin/math.hpp>
 
 namespace psim {
+namespace attitude {
 
-/** @brief Simulates attitude dynamics without fuel slosh and propagates the
- *         orbital state with a Keplerian model in ECI.
- */
-class AttitudeOrbitNoFuelEcef
-  : public AttitudeOrbit<AttitudeOrbitNoFuelEcef> {
- private:
-  typedef AttitudeOrbit<AttitudeOrbitNoFuelEcef> Super;
-  gnc::Ode4<Real, 16> ode;
+Real S(Vector4 const &q_body_eci, Vector4 const &q_eci_ecef,
+    Vector3 const &v_ecef) {
+  static constexpr Vector3 PSIM_AREA_VEC = {0.03, 0.03, 0.01};
 
- public:
-  AttitudeOrbitNoFuelEcef() = delete;
-  virtual ~AttitudeOrbitNoFuelEcef() = default;
+  Vector3 v_body;
+  gnc::utl::rotate_frame(q_eci_ecef, v_ecef, v_body);
+  gnc::utl::rotate_frame(q_body_eci, v_body);
 
-  /** @brief Set the frame argument to ECEF.
-   */
-  AttitudeOrbitNoFuelEcef(RandomsGenerator &randoms,
-      Configuration const &config, std::string const &satellite);
-
-  virtual void step() override;
-
-  Real truth_satellite_orbit_T() const;
-  Real truth_satellite_orbit_U() const;
-  Real truth_satellite_orbit_E() const;
-  Vector4 truth_satellite_attitude_q_eci_body() const;
-  Vector3 truth_satellite_attitude_L() const;
-};
+  return lin::dot(lin::abs(v_body / lin::norm(v_body)), PSIM_AREA_VEC);
+}
+} // namespace attitude
 } // namespace psim
-
-#endif

--- a/src/psim/truth/attitude_utilities.hpp
+++ b/src/psim/truth/attitude_utilities.hpp
@@ -34,13 +34,17 @@
 namespace psim {
 namespace attitude {
 
-/** @brief
+/** @brief Calculates satellite surface area projected along the direction of
+ *         travel.
  *
- *  @param[in]
+ *  @param[in] q_body_eci Rotation from ECI to body.
+ *  @param[in] q_eci_ecef Rotation from ECEF to ECI.
+ *  @param[in] v_ecef     Velocity in ECEC (m/s).
  *
- *  @return
+ *  @return Surface area projected along the direction of travel (m^2).
  */
-Real S(Vector4 const &q_body_eci, Vector4 const &q_eci_ecef, Vector3 const &v_ecef);
+Real S(Vector4 const &q_body_eci, Vector4 const &q_eci_ecef,
+    Vector3 const &v_ecef);
 
 } // namespace attitude
 } // namespace psim

--- a/src/psim/truth/attitude_utilities.hpp
+++ b/src/psim/truth/attitude_utilities.hpp
@@ -22,45 +22,27 @@
 // SOFTWARE.
 //
 
-/** @file psim/truth/attitude_orbit.hpp
+/** @file psim/truth/attitude_utilities.hpp
  *  @author Kyle Krol
  */
 
-#ifndef PSIM_TRUTH_ATTITUDE_ORBIT_HPP_
-#define PSIM_TRUTH_ATTITUDE_ORBIT_HPP_
+#ifndef PSIM_TRUTH_ATTITUDE_UTILITIES_HPP_
+#define PSIM_TRUTH_ATTITUDE_UTILITIES_HPP_
 
-#include <psim/truth/attitude_orbit.yml.hpp>
-
-#include <gnc/ode4.hpp>
+#include <psim/core/types.hpp>
 
 namespace psim {
+namespace attitude {
 
-/** @brief Simulates attitude dynamics without fuel slosh and propagates the
- *         orbital state with a Keplerian model in ECI.
+/** @brief
+ *
+ *  @param[in]
+ *
+ *  @return
  */
-class AttitudeOrbitNoFuelEcef
-  : public AttitudeOrbit<AttitudeOrbitNoFuelEcef> {
- private:
-  typedef AttitudeOrbit<AttitudeOrbitNoFuelEcef> Super;
-  gnc::Ode4<Real, 16> ode;
+Real S(Vector4 const &q_body_eci, Vector4 const &q_eci_ecef, Vector3 const &v_ecef);
 
- public:
-  AttitudeOrbitNoFuelEcef() = delete;
-  virtual ~AttitudeOrbitNoFuelEcef() = default;
-
-  /** @brief Set the frame argument to ECEF.
-   */
-  AttitudeOrbitNoFuelEcef(RandomsGenerator &randoms,
-      Configuration const &config, std::string const &satellite);
-
-  virtual void step() override;
-
-  Real truth_satellite_orbit_T() const;
-  Real truth_satellite_orbit_U() const;
-  Real truth_satellite_orbit_E() const;
-  Vector4 truth_satellite_attitude_q_eci_body() const;
-  Vector3 truth_satellite_attitude_L() const;
-};
+} // namespace attitude
 } // namespace psim
 
 #endif

--- a/src/psim/truth/satellite_truth.cpp
+++ b/src/psim/truth/satellite_truth.cpp
@@ -43,9 +43,9 @@ SatelliteTruthGnc::SatelliteTruthGnc(RandomsGenerator &randoms,
     Configuration const &config, std::string const &satellite)
   : ModelList(randoms) {
   // Dynamics
-  add<AttitudeOrbitNoFuelEciGnc>(randoms, config, satellite);
-  add<TransformPositionEci>(randoms, config, "truth." + satellite + ".orbit.r");
-  add<TransformVelocityEci>(randoms, config, satellite, "truth." + satellite + ".orbit.v");
+  add<AttitudeOrbitNoFuelEcef>(randoms, config, satellite);
+  add<TransformPositionEcef>(randoms, config, "truth." + satellite + ".orbit.r");
+  add<TransformVelocityEcef>(randoms, config, satellite, "truth." + satellite + ".orbit.v");
   // Extra telemetry
   add<NormVector3>(randoms, config, "truth." + satellite + ".attitude.L");
   add<NormVector4>(randoms, config, "truth." + satellite + ".attitude.q.body_eci");

--- a/tools/constants.csv
+++ b/tools/constants.csv
@@ -8,6 +8,8 @@ false,double,rad_to_deg,180.0 / pi
 false,float,rad_to_deg_f,rad_to_deg
 false,double,mu_earth,3.986004418e14
 false,float,mu_earth_f,mu_earth
+false,double,r_earth,6.3781e6
+false,float,r_earth_f,r_earth
 false,double,nan,std::numeric_limits<double>::quiet_NaN()
 false,float,nan_f,std::numeric_limits<float>::quiet_NaN()
 true,unsigned short,init_gps_week_number,2045


### PR DESCRIPTION
# Update Orbit Propagator in Attitude Orbit

Relates to #301.
Relates to #306.
Relates to #314 (will be rebased once this is merged).

### Summary of Changes

- Updated the orbit propagator in the attitude orbit model.
- Added a variable projected area calculation - `truth.{satellite}.orbit.S`

### Testing

Obtained with:

    python -m psim -s 100000 -p truth/orbit,truth/attitude -ps 10 -c sensors/base,truth/base,truth/deployment -v SingleAttitudeOrbitGnc

![S](https://user-images.githubusercontent.com/33558436/109406512-bcac9d00-7947-11eb-866d-fcf20ff72683.png)
![T](https://user-images.githubusercontent.com/33558436/109406513-bcac9d00-7947-11eb-89fb-5d5623d05673.png)
![eci](https://user-images.githubusercontent.com/33558436/109406579-304eaa00-7948-11eb-9879-986ced54ccbe.png)
![ecef](https://user-images.githubusercontent.com/33558436/109406581-317fd700-7948-11eb-89c5-37f2f4994845.png)


Obtained with:

    python -m psim -s 1000 -p truth/orbit,truth/attitude -ps 1 -c sensors/base,truth/base,truth/deployment -v SingleAttitudeOrbitGnc

![L](https://user-images.githubusercontent.com/33558436/109406554-00070b80-7948-11eb-8bfc-878e0fa343f3.png)
![w](https://user-images.githubusercontent.com/33558436/109406555-009fa200-7948-11eb-8edc-714408a8ad11.png)
