### PR TITLE
Potential Fix to the Shadow Set Issue

### DIFF
--- a/config/parameters/truth/detumble.txt
+++ b/config/parameters/truth/detumble.txt
@@ -9,9 +9,9 @@ truth.t.ns  1700000000000
 
 # Leader spacecraft attitude and orbit initial conditions.
 
-truth.leader.attitude.q.body_eci  0.0629875 -0.185791 0.19747   -0.960479
-truth.leader.attitude.w          -0.077216   0.294684 0.0952384
-truth.leader.wheels.w             0.0        0.0      0.0
+truth.leader.attitude.q.body_eci -0.0629875 0.185791 -0.19747   0.960479
+truth.leader.attitude.w          -0.077216  0.294684  0.0952384
+truth.leader.wheels.w             0.0       0.0       0.0
 
 truth.leader.orbit.r  -2.16431e6  4.60304e6  4.5925e6
 truth.leader.orbit.v  -7236.19   -1695.2    -1708.76


### PR DESCRIPTION
Relates to #318.

### Summary of changes

- Negated a quaternion in the configuration files.

I just have a hunch our triad algorithm may always return a quaternion with a positive real component so...I just matched in and everything seems happy for now.

### Testing

The following plots were generated using the same command noted in the ticket:

    python -m psim -s 1000 -p fc/attitude -ps 1 -c sensors/base,truth/base,truth/detumble -v AttitudeEstimatorTestGnc

![px](https://user-images.githubusercontent.com/33558436/109406919-e0bdad80-794a-11eb-9a4b-988cf5704178.png)
![qdeg](https://user-images.githubusercontent.com/33558436/109406920-e0bdad80-794a-11eb-87e4-3312e81c4e44.png)
![w](https://user-images.githubusercontent.com/33558436/109406921-e0bdad80-794a-11eb-8c42-8145433d33cb.png)

