### PR TITLE
Detumbler Simulation and Unit Test

### DIFF
--- a/.github/workflows/psim.yml
+++ b/.github/workflows/psim.yml
@@ -22,17 +22,17 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get install bazel
-        pip install --upgrade pip
-        pip install -v lib/lin
+        pip install --upgrade pip wheel
+        pip install lib/lin
+
+    - name: Build and install the psim Python module
+      run: |
+        pip install -e .
 
     - name: Build and run C++ unit tests
       run: |
         bazel test //test/psim:ci
 
-    - name: Build and install psim Python module
+    - name: Run Python unit tests
       run: |
-        pip install -v -e .
-
-    - name: Build and run Python tests
-      run: |
-        python -m psim --help
+        pytest python

--- a/.github/workflows/psim.yml
+++ b/.github/workflows/psim.yml
@@ -23,6 +23,7 @@ jobs:
       run: |
         sudo apt-get install bazel
         pip install --upgrade pip wheel
+        pip install ptest
         pip install lib/lin
 
     - name: Build and install the psim Python module

--- a/.github/workflows/psim.yml
+++ b/.github/workflows/psim.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         sudo apt-get install bazel
         pip install --upgrade pip wheel
-        pip install ptest
+        pip install pytest
         pip install lib/lin
 
     - name: Build and install the psim Python module

--- a/include/psim/fc/detumbler.hpp
+++ b/include/psim/fc/detumbler.hpp
@@ -1,0 +1,54 @@
+//
+// MIT License
+//
+// Copyright (c) 2020 Pathfinder for Autonomous Navigation (PAN)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+/** @file psim/fc/detumbler.hpp
+ *  @author Kyle Krol
+ */
+
+#ifndef PSIM_FC_DETUMBLER_HPP_
+#define PSIM_FC_DETUMBLER_HPP_
+
+#include <psim/fc/detumbler.yml.hpp>
+
+#include <gnc/attitude_controller.hpp>
+
+namespace psim {
+
+class Detumbler : public DetumblerInterface<Detumbler> {
+ private:
+  typedef DetumblerInterface<Detumbler> Super;
+
+  gnc::DetumbleControllerState _detumbler;
+
+ public:
+  using Super::DetumblerInterface;
+
+  Detumbler() = delete;
+  virtual ~Detumbler() = default;
+
+  virtual void step() override;
+};
+} // namespace psim
+
+#endif

--- a/include/psim/fc/detumbler.yml
+++ b/include/psim/fc/detumbler.yml
@@ -1,0 +1,15 @@
+
+name: DetumblerInterface
+type: Model
+comment: >
+    Interface for how the detumbler will interact with the rest of the
+    simulation.
+
+args:
+    - satellite
+
+gets:
+    - name: "truth.{satellite}.magnetorquers.m"
+      type: Writable Vector3
+    - name: "sensors.{satellite}.magnetometer.b"
+      type: Vector3

--- a/include/psim/simulations/detumbler_test.hpp
+++ b/include/psim/simulations/detumbler_test.hpp
@@ -1,0 +1,49 @@
+//
+// MIT License
+//
+// Copyright (c) 2020 Pathfinder for Autonomous Navigation (PAN)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+/** @file psim/simulation/detumbler_test.hpp
+ *  @author Kyle Krol
+ */
+
+#ifndef PSIM_SIMULATIONS_DETUMBLER_TEST_HPP_
+#define PSIM_SIMULATIONS_DETUMBLER_TEST_HPP_
+
+#include <psim/core/configuration.hpp>
+#include <psim/core/model_list.hpp>
+
+namespace psim {
+
+/** @brief Models the detumbler running on the flight computer.
+ */
+class DetumblerTest : public ModelList {
+ public:
+  DetumblerTest() = delete;
+  virtual ~DetumblerTest() = default;
+
+  DetumblerTest(
+      RandomsGenerator &randoms, Configuration const &config);
+};
+} // namespace psim
+
+#endif

--- a/python/psim/_psim.cpp
+++ b/python/psim/_psim.cpp
@@ -35,6 +35,7 @@
 #include <psim/core/types.hpp>
 
 #include <psim/simulations/attitude_estimator_test.hpp>
+#include <psim/simulations/detumbler_test.hpp>
 #include <psim/simulations/dual_attitude_orbit.hpp>
 #include <psim/simulations/dual_orbit.hpp>
 #include <psim/simulations/orbit_estimator_test.hpp>
@@ -188,6 +189,7 @@ static void py_assign(psim::StateFieldWritableBase &field, T const &value) {
 
 void py_simulation(py::module &m) {
   PY_SIMULATION(AttitudeEstimatorTestGnc);
+  PY_SIMULATION(DetumblerTest);
   PY_SIMULATION(SingleAttitudeOrbitGnc);
   PY_SIMULATION(SingleOrbitGnc);
   PY_SIMULATION(OrbOrbitEstimatorTest);

--- a/python/psim/sims.py
+++ b/python/psim/sims.py
@@ -3,6 +3,7 @@
 
 from _psim import (
     AttitudeEstimatorTestGnc,
+    DetumblerTest,
     DualAttitudeOrbitGnc,
     DualOrbitGnc,
     OrbOrbitEstimatorTest,

--- a/python/test/test_detumbler.py
+++ b/python/test/test_detumbler.py
@@ -1,0 +1,37 @@
+from psim import Configuration, sims, Simulation
+
+import lin
+import pytest
+
+
+def test_detumbler():
+    """Test the detumbler.
+
+    This boots the simulation starting right after the deployment hold has been
+    completed - i.e. forty minutes after a simultaneous deployment. We're
+    essentially checking that the detumbler can bring the total angular momentum
+    of the spacecraft below a given threshold in a appropriate amount of time.
+
+    This currently detumbles in about 22361 steps.
+    """
+    configs = ['sensors/base', 'truth/base', 'truth/detumble']
+    configs = ['config/parameters/' + f + '.txt' for f in configs]
+
+    config = Configuration(configs)
+    sim = Simulation(sims.DetumblerTest, config)
+
+    # Wait up to four hours for the spacecraft to have detumbled
+    timeout = 4 * 60 * 60 * 1000000000 + sim['truth.t.ns']
+
+    # Angular momentum threshold to determine if we've detumbled
+    #
+    # Reference(s):
+    #  - https://github.com/pathfinder-for-autonomous-navigation/FlightSoftware/blob/2e3e133c49c44e8c792f3c7bef1b6e43ad2f3141/src/fsw/FCCode/MissionManager.cpp#L201-L215
+    threshold = 1047 * 1.35e-5 * 0.33
+
+    sim.step()
+    steps = 1
+    while sim['truth.leader.attitude.L.norm'] > threshold:
+        assert sim['truth.t.ns'] < timeout, 'Spacecraft failed to detumble in alloted time'
+        sim.step()
+        steps = steps + 1

--- a/python/test/test_detumbler.py
+++ b/python/test/test_detumbler.py
@@ -30,8 +30,6 @@ def test_detumbler():
     threshold = 1047 * 1.35e-5 * 0.33
 
     sim.step()
-    steps = 1
     while sim['truth.leader.attitude.L.norm'] > threshold:
         assert sim['truth.t.ns'] < timeout, 'Spacecraft failed to detumble in alloted time'
         sim.step()
-        steps = steps + 1

--- a/src/psim/fc/detumbler.cpp
+++ b/src/psim/fc/detumbler.cpp
@@ -1,0 +1,56 @@
+//
+// MIT License
+//
+// Copyright (c) 2020 Pathfinder for Autonomous Navigation (PAN)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+/** @file psim/fc/detumbler.cpp
+ *  @author Kyle Krol
+ */
+
+#include <psim/fc/detumbler.hpp>
+
+#include <lin/core.hpp>
+#include <lin/generators.hpp>
+#include <lin/math.hpp>
+#include <lin/queries.hpp>
+
+namespace psim {
+
+void Detumbler::step() {
+  this->Super::step();
+
+  auto const &b_body = sensors_satellite_magnetometer_b->get();
+  auto &m_body = truth_satellite_magnetorquers_m->get();
+
+  gnc::DetumbleControllerData data;
+  data.b_body = b_body;
+
+  gnc::DetumbleActuation actutation;
+  gnc::control_detumble(_detumbler, data, actutation);
+
+  if (lin::all(lin::isfinite(actutation.mtr_body_cmd))) {
+    m_body = lin::cast<Real>(actutation.mtr_body_cmd);
+  } else {
+    m_body = lin::zeros<Vector3>();
+  }
+}
+} // namespace psim

--- a/src/psim/simulations/detumbler_test.cpp
+++ b/src/psim/simulations/detumbler_test.cpp
@@ -1,0 +1,42 @@
+//
+// MIT License
+//
+// Copyright (c) 2020 Pathfinder for Autonomous Navigation (PAN)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+/** @file psim/simulation/detumbler_test.hpp
+ *  @author Kyle Krol
+ */
+
+#include <psim/simulations/detumbler_test.hpp>
+
+#include <psim/fc/detumbler.hpp>
+#include <psim/simulations/single_attitude_orbit.hpp>
+
+namespace psim {
+
+DetumblerTest::DetumblerTest(
+    RandomsGenerator &randoms, Configuration const &config)
+  : ModelList(randoms) {
+  add<SingleAttitudeOrbitGnc>(randoms, config);
+  add<Detumbler>(randoms, config, "leader");
+}
+} // namespace psim


### PR DESCRIPTION
Relates to #320.

### Summary of changes
- Added a `Detumbler` model.
- Added a `DetumblerTest` simulation.
- Added a Python unit test to ensure the satellite will detumble in a reasonable amount of time.

This detumbler test simulation will also be used to generate initial conditions which should allow `ptest` cases to quickly boot into standby. This will be done in a separate PR.