### PR TITLE
Hotfix: Disable Orbit Validity Velocity Checks

### DIFF
--- a/include/orb/Orbit.h
+++ b/include/orb/Orbit.h
@@ -137,7 +137,6 @@ class Orbit {
             //time check
             if (!(_ns_gps_time <= MAXGPSTIME_NS)) goto INVALID;
             if (!(_ns_gps_time >= MINGPSTIME_NS)) goto INVALID;
-
             //position check
             lin::Vector3f recef_f=_recef;
             float r2= lin::fro(recef_f);//lin::fro is Frobenius (aka Euclidean) norm squared
@@ -145,7 +144,6 @@ class Orbit {
             //note if position is NAN, these checks will fail.
             if (!(r2 <= MAXORBITRADIUS*MAXORBITRADIUS)) goto INVALID;
             if (!(r2 >= MINORBITRADIUS*MINORBITRADIUS)) goto INVALID;
-
             //position and velocity check
             //float w= 0.729211585530000E-4;
             //float mu= PANGRAVITYMODEL.earth_gravity_constant;

--- a/include/orb/Orbit.h
+++ b/include/orb/Orbit.h
@@ -30,19 +30,25 @@ SOFTWARE.
  */
 
 #pragma once
+
+#include "JacobianHelpers/jacobian_autocoded.h"
+
+#include <gnc/config.hpp>
+#include <gnc/constants.hpp>
+
+#include <lin/core.hpp>
+#include <lin/generators.hpp>
+#include <lin/math.hpp>
+#include <lin/queries.hpp>
+
+#include <geograv.hpp>
+#include <GGM05S.hpp>
+
+#include <array>
 #include <cstdint>
 #include <cstdlib>
 #include <cmath>
 #include <limits>
-#include <array>
-#include <lin/core.hpp>
-#include <lin/generators.hpp>
-#include <gnc/config.hpp>
-#include <gnc/constants.hpp>
-#include "JacobianHelpers/jacobian_autocoded.h"
-
-#include <geograv.hpp>
-#include <GGM05S.hpp>
 
 namespace orb
 {
@@ -131,6 +137,7 @@ class Orbit {
             //time check
             if (!(_ns_gps_time <= MAXGPSTIME_NS)) goto INVALID;
             if (!(_ns_gps_time >= MINGPSTIME_NS)) goto INVALID;
+
             //position check
             lin::Vector3f recef_f=_recef;
             float r2= lin::fro(recef_f);//lin::fro is Frobenius (aka Euclidean) norm squared
@@ -138,22 +145,30 @@ class Orbit {
             //note if position is NAN, these checks will fail.
             if (!(r2 <= MAXORBITRADIUS*MAXORBITRADIUS)) goto INVALID;
             if (!(r2 >= MINORBITRADIUS*MINORBITRADIUS)) goto INVALID;
+
             //position and velocity check
-            float w= 0.729211585530000E-4;
-            float mu= PANGRAVITYMODEL.earth_gravity_constant;
-            lin::Vector3f vecef0_f=_vecef;
-            vecef0_f= vecef0_f + lin::Vector3f({-w*recef_f(1),w*recef_f(0),0.0f});
+            //float w= 0.729211585530000E-4;
+            //float mu= PANGRAVITYMODEL.earth_gravity_constant;
+            //lin::Vector3f vecef0_f=_vecef;
+            //vecef0_f= vecef0_f + lin::Vector3f({-w*recef_f(1),w*recef_f(0),0.0f});
             //e is the specific orbital energy
             //lin::fro is Frobenius (aka Euclidean) norm squared
-            float e= lin::fro(vecef0_f)*0.5f-mu/std::sqrt(r2);
+            //float e= lin::fro(vecef0_f)*0.5f-mu/std::sqrt(r2);
             //h2 is norm squared of specific orbital angular momentum
-            float h2= lin::fro(lin::cross(recef_f,vecef0_f));
+            //float h2= lin::fro(lin::cross(recef_f,vecef0_f));
             //ep and ea are the lowest specific orbital energy if h2 is the same at max and min radius
-            float ep= h2*(0.5f/(MINORBITRADIUS*MINORBITRADIUS))-mu/MINORBITRADIUS;
-            float ea= h2*(0.5f/(MAXORBITRADIUS*MAXORBITRADIUS))-mu/MAXORBITRADIUS;
+            //float ep= h2*(0.5f/(MINORBITRADIUS*MINORBITRADIUS))-mu/MINORBITRADIUS;
+            //float ea= h2*(0.5f/(MAXORBITRADIUS*MAXORBITRADIUS))-mu/MAXORBITRADIUS;
             //note if velocity is NAN, these checks will fail.
-            if (!(e <= ea)) goto INVALID;
-            if (!(e <= ep)) goto INVALID;
+            //if (!(e <= ea)) goto INVALID;
+            //if (!(e <= ep)) goto INVALID;
+
+            // Hack because this was causing validity issues in flight software
+            // it seems potentially dangerous to let the orbit disable the
+            // filter like this?
+            if (!lin::all(lin::isfinite(_vecef)))
+                goto INVALID;
+
             //made it through all checks
             _valid= true;
             return;

--- a/test/gnc/orbit/orbit_test.cpp
+++ b/test/gnc/orbit/orbit_test.cpp
@@ -128,19 +128,21 @@ void test_validity_checks () {
     y=orb::Orbit(panepoch,gracestart.recef(),gracestart.vecef());
     TEST_ASSERT_TRUE(y.valid());
 
+    // TODO : Update validity checks later on
+
     //orbit checks to fail
-    y=orb::Orbit(panepoch,gracestart.recef(),{0.0,0.0,0.0});
-    TEST_ASSERT_FALSE(y.valid());
+    //y=orb::Orbit(panepoch,gracestart.recef(),{0.0,0.0,0.0});
+    //TEST_ASSERT_FALSE(y.valid());
     y=orb::Orbit(panepoch,gracestart.recef(),{0.0,gnc::constant::nan,0.0});
     TEST_ASSERT_FALSE(y.valid());
-    y=orb::Orbit(panepoch,gracestart.recef(),{0.0,1.0E5,0.0});
-    TEST_ASSERT_FALSE(y.valid());
-    y=orb::Orbit(panepoch,gracestart.recef(),{0.0,1.0E10,0.0});
-    TEST_ASSERT_FALSE(y.valid());
-    y=orb::Orbit(panepoch,gracestart.recef(),{0.0,4.0E3,0.0});
-    TEST_ASSERT_FALSE(y.valid());
-    y=orb::Orbit(panepoch,gracestart.recef(),-1.0E-3*gracestart.recef());
-    TEST_ASSERT_FALSE(y.valid());
+    //y=orb::Orbit(panepoch,gracestart.recef(),{0.0,1.0E5,0.0});
+    //TEST_ASSERT_FALSE(y.valid());
+    //y=orb::Orbit(panepoch,gracestart.recef(),{0.0,1.0E10,0.0});
+    //TEST_ASSERT_FALSE(y.valid());
+    //y=orb::Orbit(panepoch,gracestart.recef(),{0.0,4.0E3,0.0});
+    //TEST_ASSERT_FALSE(y.valid());
+    //y=orb::Orbit(panepoch,gracestart.recef(),-1.0E-3*gracestart.recef());
+    //TEST_ASSERT_FALSE(y.valid());
 
     //orbit checks to pass
     y=orb::Orbit(panepoch,gracestart.recef(),gracestart.vecef());
@@ -159,8 +161,8 @@ void test_validity_checks () {
     TEST_ASSERT_FALSE(y.valid());
     y=orb::Orbit(panepoch,gracestart.recef(),gracestart.vecef());
     TEST_ASSERT_TRUE(y.valid());
-    y.applydeltav({0.0,1.0E6,0.0});
-    TEST_ASSERT_FALSE(y.valid());
+    //y.applydeltav({0.0,1.0E6,0.0});
+    //TEST_ASSERT_FALSE(y.valid());
 }
 
 void test_calc_geograv() {


### PR DESCRIPTION
This was causing orbit estimator initialization to fail on the flight computer -- I believe the bounds on the validity check are just extremely strict. I'm opening a ticket to fix this but for the time being want to get this fix in so flight software development and mission rehearsal work isn't delayed.