### PR TITLE
Created orbit controller unit test

### DIFF
--- a/python/test/test_orbit_controller.py
+++ b/python/test/test_orbit_controller.py
@@ -1,0 +1,24 @@
+from psim import Configuration, sims, Simulation
+
+import lin
+import pytest
+
+
+def test_orbit_controller():
+    """Test the orbit controller.
+    This boots the simulation starting in standby (after detumbling)
+    """
+    configs = ['sensors/base', 'truth/base', 'truth/standby']
+    configs = ['config/parameters/' + f + '.txt' for f in configs]
+
+    config = Configuration(configs)
+    sim = Simulation(sims.OrbitControllerTest, config)
+
+    #The spacecrafts are given 10 days to rendezvous
+    timeout = 10 * 24 * 3600 * 1e9
+    threshold = 0.5
+    sim.step()
+
+    while sim['truth.leader.hill.dr.norm'] > threshold:
+        assert sim['truth.t.ns'] < timeout , 'Spacecrafts failed to rendezvous in alloted time'
+        sim.step()


### PR DESCRIPTION
# Orbit Controller Unit Test


### Summary of changes
Created a unit test for orbit controller. Throws error if spacecrafts fail to rendezvous in 10 days. Here, rendezvous is defined as <0.5m.

### Testing
Currently, rendezvous occurs in about 9.5 days, so 10 days was chosen as the threshold for regression. Below are plots of the current performance of the simulation. For reference, 821,000 seconds is ~9.5 days.
![dr_vec](https://user-images.githubusercontent.com/6196536/111882611-dceedb00-898c-11eb-9d70-0cf164c7b4d9.png)
![dr_norm](https://user-images.githubusercontent.com/6196536/111882614-df513500-898c-11eb-9844-4e9658e0c95e.png)
![dr_norm_zoomed](https://user-images.githubusercontent.com/6196536/111882620-e11af880-898c-11eb-9d2e-133cd06ec500.png)


