### PR TITLE
Improve Get Field Error Messages in Model

### DIFF
--- a/include/psim/core/model.hpp
+++ b/include/psim/core/model.hpp
@@ -68,12 +68,17 @@ class Model {
    *  @return Pointer to the state field.
    *
    *  Note, if the field wasn't found or has an invalid underlying type, a
-   * runtime error will be thrown.
+   *  runtime error will be thrown.
    */
   template <typename T>
   StateField<T> const *get_field(State const &state, std::string const &name) {
+    auto const *base_field_ptr = state.get(name);
+    if (!base_field_ptr)
+      throw std::runtime_error(
+          "Entry not found while getting a field: " + name);
+
     auto const *field_ptr =
-        dynamic_cast<StateField<T> const *>(state.get(name));
+        dynamic_cast<StateField<T> const *>(base_field_ptr);
     if (!field_ptr)
       throw std::runtime_error("Invalid cast while getting a field: " + name);
 
@@ -95,8 +100,13 @@ class Model {
   template <typename T>
   StateFieldWritable<T> *get_writable_field(
       State &state, std::string const &name) {
+    auto *base_field_ptr = state.get_writable(name);
+    if (!base_field_ptr)
+      throw std::runtime_error(
+          "Entry not found while getting a writable field:" + name);
+
     auto *field_ptr =
-        dynamic_cast<StateFieldWritable<T> *>(state.get_writable(name));
+        dynamic_cast<StateFieldWritable<T> *>(base_field_ptr);
     if (!field_ptr)
       throw std::runtime_error(
           "Invalid cast while getting a writable field: " + name);

--- a/include/psim/core/model.hpp
+++ b/include/psim/core/model.hpp
@@ -77,10 +77,11 @@ class Model {
       throw std::runtime_error(
           "Entry not found while getting a field: " + name);
 
-    auto const *field_ptr =
-        dynamic_cast<StateField<T> const *>(base_field_ptr);
+    auto const *field_ptr = dynamic_cast<StateField<T> const *>(base_field_ptr);
     if (!field_ptr)
-      throw std::runtime_error("Invalid cast while getting a field: " + name);
+      throw std::runtime_error(
+          "Invalid cast while getting a field - " +
+          base_field_ptr->name() + ":" + base_field_ptr->type());
 
     return field_ptr;
   }
@@ -105,11 +106,11 @@ class Model {
       throw std::runtime_error(
           "Entry not found while getting a writable field:" + name);
 
-    auto *field_ptr =
-        dynamic_cast<StateFieldWritable<T> *>(base_field_ptr);
+    auto *field_ptr = dynamic_cast<StateFieldWritable<T> *>(base_field_ptr);
     if (!field_ptr)
       throw std::runtime_error(
-          "Invalid cast while getting a writable field: " + name);
+          "Invalid cast while getting a writable field - " +
+          base_field_ptr->name() + ":" + base_field_ptr->type());
 
     return field_ptr;
   }


### PR DESCRIPTION
### Summary of Changes

Before this change, it wasn't possible to distinguish whether field retrieval failed because a field didn't exist or the cast was invalid. This removes that ambiguity.

### Testing

CI boots up simulation and should be totally sufficient to verify the change is correct.