### PR TITLE
Infrastructure for Boolean State Fields and Parameters

### DIFF
--- a/include/psim/core/types.hpp
+++ b/include/psim/core/types.hpp
@@ -34,37 +34,63 @@
 
 namespace psim {
 
-/** @brief Types that are held by parameters and fields and transactable with
- *         Python.
+/** @brief Boolean parameter and field type used throughout psim.
  *
- *  @{
+ *  This type is transactable to and from Python.
  */
-typedef long Integer;
-typedef double Real;
-typedef lin::Vector2d Vector2;
-typedef lin::Vector3d Vector3;
-typedef lin::Vector4d Vector4;
-/** @}
- */
+using Boolean = bool;
 
-/** @brief Standardized matrix and vector types for use throughout psim.
+/** @brief Signed integer parameter and field type used throughout psim.
  *
- *  @{
+ *  This type is transactable to and from Python.
+ */
+using Integer = long;
+
+/** @brief Floating point parameter and field type used throughout psim.
+ *
+ *  This type is transactable to and from Python.
+ */
+using Real = double;
+
+/** @brief Standardized vector type used throughout psim.
  */
 template <lin::size_t N, lin::size_t MN = N>
 using Vector = lin::Vector<Real, N, MN>;
 
+/** @brief Two dimensional floating point vector parameter and field type used
+ *         throughout psim.
+ *
+ *  This type is transactable to and from Python.
+ */
+using Vector2 = Vector<2>;
+
+/** @brief Three dimensional floating point vector parameter and field type used
+ *         throughout psim.
+ *
+ *  This type is transactable to and from Python.
+ */
+using Vector3 = Vector<3>;
+
+/** @brief Four dimensional floating point vector parameter and field type used
+ *         throughout psim.
+ *
+ *  This type is transactable to and from Python.
+ */
+using Vector4 = Vector<4>;
+
+/** @brief Standardized row vector type used throughout psim.
+ */
 template <lin::size_t N, lin::size_t MN = N>
 using RowVector = lin::RowVector<Real, N, MN>;
 
+/** @brief Standardized matrix type used throughout psim.
+ */
 template <lin::size_t R, lin::size_t C, lin::size_t MR = R, lin::size_t MC = C>
 using Matrix = lin::Matrix<Real, R, C, MR, MC>;
-/** @}
- */
 
-/** @brief Used as a random number generator for all simulations.
+/** @brief Randoms number generator used throughout psim.
  */
-typedef lin::internal::RandomsGenerator RandomsGenerator;
+using RandomsGenerator = lin::internal::RandomsGenerator;
 
 } // namespace psim
 

--- a/python/psim/_psim.cpp
+++ b/python/psim/_psim.cpp
@@ -70,7 +70,8 @@ struct visit_helper<mapbox::util::variant> {
 }  // namespace detail
 }  // namespace pybind11
 
-using PyVariant = mapbox::util::variant<psim::Integer, psim::Real, psim::Vector2, psim::Vector3, psim::Vector4>;
+using PyVariant = mapbox::util::variant<
+    psim::Boolean, psim::Integer, psim::Real, psim::Vector2, psim::Vector3, psim::Vector4>;
 
 namespace py = pybind11;
 
@@ -91,18 +92,6 @@ class PyConfiguration : public psim::Configuration {
     if (!param)
       throw std::runtime_error("Parameter '" + name + "' does not exist.");
     {
-      auto const *ptr = dynamic_cast<psim::Parameter<psim::Integer> const *>(param);
-      if (ptr) return ptr->get();
-    }
-    {
-      auto const *ptr = dynamic_cast<psim::Parameter<psim::Real> const *>(param);
-      if (ptr) return ptr->get();
-    }
-    {
-      auto const *ptr = dynamic_cast<psim::Parameter<psim::Vector2> const *>(param);
-      if (ptr) return ptr->get();
-    }
-    {
       auto const *ptr = dynamic_cast<psim::Parameter<psim::Vector3> const *>(param);
       if (ptr) return ptr->get();
     }
@@ -110,16 +99,33 @@ class PyConfiguration : public psim::Configuration {
       auto const *ptr = dynamic_cast<psim::Parameter<psim::Vector4> const *>(param);
       if (ptr) return ptr->get();
     }
+    {
+      auto const *ptr = dynamic_cast<psim::Parameter<psim::Real> const *>(param);
+      if (ptr) return ptr->get();
+    }
+    {
+      auto const *ptr = dynamic_cast<psim::Parameter<psim::Boolean> const *>(param);
+      if (ptr) return ptr->get();
+    }
+    {
+      auto const *ptr = dynamic_cast<psim::Parameter<psim::Integer> const *>(param);
+      if (ptr) return ptr->get();
+    }
+    {
+      auto const *ptr = dynamic_cast<psim::Parameter<psim::Vector2> const *>(param);
+      if (ptr) return ptr->get();
+    }
     throw std::runtime_error("Parameter '" + name + "' holds an unsupported type.");
   }
 
   void set(std::string const &name, PyVariant const &value) {
     value.match(
-      [this, &name](psim::Real    const &v) { _set(name, v); },
-      [this, &name](psim::Integer const &v) { _set(name, v); },
-      [this, &name](psim::Vector2 const &v) { _set(name, v); },
-      [this, &name](psim::Vector3 const &v) { _set(name, v); },
-      [this, &name](psim::Vector4 const &v) { _set(name, v); }
+      [&](psim::Real    const &v) { this->_set(name, v); },
+      [&](psim::Boolean const &v) { this->_set(name, v); },
+      [&](psim::Integer const &v) { this->_set(name, v); },
+      [&](psim::Vector2 const &v) { this->_set(name, v); },
+      [&](psim::Vector3 const &v) { this->_set(name, v); },
+      [&](psim::Vector4 const &v) { this->_set(name, v); }
     );
   }
 };
@@ -151,7 +157,11 @@ static void py_assign(psim::StateFieldWritableBase &field, T const &value) {
         if (!field) \
           throw std::runtime_error("State field '" + name + "' does not exist."); \
         { \
-            auto const *ptr = dynamic_cast<psim::StateField<psim::Integer> const *>(field); \
+            auto const *ptr = dynamic_cast<psim::StateField<psim::Vector3> const *>(field); \
+            if (ptr) return ptr->get(); \
+        } \
+        { \
+            auto const *ptr = dynamic_cast<psim::StateField<psim::Vector4> const *>(field); \
             if (ptr) return ptr->get(); \
         } \
         { \
@@ -159,15 +169,15 @@ static void py_assign(psim::StateFieldWritableBase &field, T const &value) {
             if (ptr) return ptr->get(); \
         } \
         { \
+            auto const *ptr = dynamic_cast<psim::StateField<psim::Boolean> const *>(field); \
+            if (ptr) return ptr->get(); \
+        } \
+        { \
+            auto const *ptr = dynamic_cast<psim::StateField<psim::Integer> const *>(field); \
+            if (ptr) return ptr->get(); \
+        } \
+        { \
             auto const *ptr = dynamic_cast<psim::StateField<psim::Vector2> const *>(field); \
-            if (ptr) return ptr->get(); \
-        } \
-        { \
-            auto const *ptr = dynamic_cast<psim::StateField<psim::Vector3> const *>(field); \
-            if (ptr) return ptr->get(); \
-        } \
-        { \
-            auto const *ptr = dynamic_cast<psim::StateField<psim::Vector4> const *>(field); \
             if (ptr) return ptr->get(); \
         } \
         throw std::runtime_error("State field '" + name + "' holds an unsupported type."); \
@@ -177,11 +187,12 @@ static void py_assign(psim::StateFieldWritableBase &field, T const &value) {
         if (!ptr) \
           throw std::runtime_error("Writable state field '" + name + "' does not exist."); \
         value.match( \
-          [&ptr](psim::Real    const &v) { py_assign(*ptr, v); }, \
-          [&ptr](psim::Integer const &v) { py_assign(*ptr, v); }, \
-          [&ptr](psim::Vector2 const &v) { py_assign(*ptr, v); }, \
-          [&ptr](psim::Vector3 const &v) { py_assign(*ptr, v); }, \
-          [&ptr](psim::Vector4 const &v) { py_assign(*ptr, v); } \
+          [&](psim::Real    const &v) { py_assign(*ptr, v); }, \
+          [&](psim::Boolean const &v) { py_assign(*ptr, v); }, \
+          [&](psim::Integer const &v) { py_assign(*ptr, v); }, \
+          [&](psim::Vector2 const &v) { py_assign(*ptr, v); }, \
+          [&](psim::Vector3 const &v) { py_assign(*ptr, v); }, \
+          [&](psim::Vector4 const &v) { py_assign(*ptr, v); }  \
         ); \
       }) \
       .def("step", [](psim::Simulation<psim::model> &self) { \

--- a/src/psim/core/configuration.cpp
+++ b/src/psim/core/configuration.cpp
@@ -102,7 +102,11 @@ void Configuration::_parse(std::string const &file) {
             "Only one token detected in the following line: '" + line + "'");
 
       case 2:
-        if (tokens[1].find('.') == std::string::npos)
+        if (tokens[1] == "true")
+          _add(tokens[0], true, file, l);
+        else if (tokens[1] == "false")
+          _add(tokens[0], false, file, l);
+        else if (tokens[1].find('.') == std::string::npos)
           _add(tokens[0], std::stol(tokens[1]), file, l);
         else
           _add(tokens[0], std::stod(tokens[1]), file, l);

--- a/test/psim/core/configuration_test.cpp
+++ b/test/psim/core/configuration_test.cpp
@@ -82,6 +82,17 @@ TEST(Configuration, TestSingleFileMake) {
     ASSERT_EQ(test_integer, -2);
   }
 
+  // Check Boolean fields(s)
+  {
+    psim::Boolean test_boolean;
+
+    test_boolean = config["test.true"].template get<psim::Boolean>();
+    ASSERT_TRUE(test_boolean);
+
+    test_boolean = config["test.false"].template get<psim::Boolean>();
+    ASSERT_FALSE(test_boolean);
+  }
+
   // Check Real field(s)
   {
     psim::Real test_real;

--- a/test/psim/core/configuration_test_config.txt
+++ b/test/psim/core/configuration_test_config.txt
@@ -11,6 +11,10 @@
 # instead of an Integer.
 #
 
+test.true true
+
+test.false false
+
 test.integer  1
 test.i       -2
 

--- a/tools/autocoder.py
+++ b/tools/autocoder.py
@@ -88,7 +88,7 @@ class Variable(Commented):
         # Underlying type
         underlying_type_matches = 0
         self.__underlying_type = None
-        for underlying_type in ['Integer', 'Real', 'Vector2', 'Vector3', 'Vector4']:
+        for underlying_type in ['Boolean', 'Integer', 'Real', 'Vector2', 'Vector3', 'Vector4']:
             if underlying_type in self._type:
                 underlying_type_matches = underlying_type_matches + 1
                 self.__underlying_type = underlying_type


### PR DESCRIPTION

### Summary of changes

Added infrastructure for boolean state fields and parameters. This included state fields defined in the model interface files.

You can now add a boolean configuration values like this

    test.true   true
    test.false  false

and declare boolean state fields/parameters with the `Boolean` keyword.

### Ptest Effects

NA

### Testing

Expanded unit tests for the configuration system and have models running locally with autocoded boolean state fields using these changes.
