### PR TITLE
Fix Deprecation Warning

### DIFF
--- a/python/psim/simulation.py
+++ b/python/psim/simulation.py
@@ -10,7 +10,7 @@ import logging
 
 log = logging.getLogger(__name__)
 
-_BANNER = """
+_BANNER = r'''
 ,-.----.                                 ____   
 \    /  \    .--.--.      ,---,        ,'  , `.
 |   :    \  /  /    '. ,`--.' |     ,-+-,.' _ |
@@ -25,7 +25,7 @@ _BANNER = """
 |   | :      `--'---'  ;   |.' ;   | |`-'
 `---'.|                '---'   |   ;/ 
   `---`                        '---'
-"""
+'''
 
 _DESCRIPTION = """
 Command line interface for running standalone PSim simulations.


### PR DESCRIPTION
Just fixed a Python deprecation warning by moving to a raw string literal.