### PR TITLE
Allows PSim to run without sun vectors 

### DIFF
--- a/src/psim/fc/attitude_estimator.cpp
+++ b/src/psim/fc/attitude_estimator.cpp
@@ -76,8 +76,13 @@ void AttitudeEstimator::step() {
   }
   // Attempt to reset the current estimate if it isn't valid.
   else {
-    if (lin::all(lin::isfinite(t)) && lin::all(lin::isfinite(r)) &&
-        lin::all(lin::isfinite(b)) && lin::all(lin::isfinite(s)))
+    if (!lin::all(lin::isfinite(s)))
+         {
+             gnc::attitude_estimator_reset(
+                     _attitude_state, t, {0.0f, 0.0f, 0.0f, 1.0f});
+         }
+    else if (lin::all(lin::isfinite(t)) && lin::all(lin::isfinite(r)) &&
+        lin::all(lin::isfinite(b)))
       gnc::attitude_estimator_reset(_attitude_state, t, r, b, s);
   }
 

--- a/src/psim/fc/attitude_estimator.cpp
+++ b/src/psim/fc/attitude_estimator.cpp
@@ -76,13 +76,11 @@ void AttitudeEstimator::step() {
   }
   // Attempt to reset the current estimate if it isn't valid.
   else {
-    if (!lin::all(lin::isfinite(s)))
-         {
-             gnc::attitude_estimator_reset(
-                     _attitude_state, t, {0.0f, 0.0f, 0.0f, 1.0f});
-         }
-    else if (lin::all(lin::isfinite(t)) && lin::all(lin::isfinite(r)) &&
-        lin::all(lin::isfinite(b)))
+    if (!lin::all(lin::isfinite(s))) {
+      gnc::attitude_estimator_reset(
+          _attitude_state, t, {0.0f, 0.0f, 0.0f, 1.0f});
+    } else if (lin::all(lin::isfinite(t)) && lin::all(lin::isfinite(r)) &&
+               lin::all(lin::isfinite(b)))
       gnc::attitude_estimator_reset(_attitude_state, t, r, b, s);
   }
 


### PR DESCRIPTION
# PSim No Sun Vector Update


### Summary of changes
- In PR #795 in FSW the functionality to turn off sun vectors was added, but the fc model in psim was not updated
- This PR updates that model 

