### PR TITLE
Implemented Noise Radius and Config on Thruster Impulse

### DIFF
--- a/config/parameters/fc/base.txt
+++ b/config/parameters/fc/base.txt
@@ -7,5 +7,10 @@ fc.follower.fire_time_far     1800
 fc.follower.fire_time_near    300
 
 # Ideally these would be in an actuators folder...
-fc.leader.thruster.noise_radius 1.0
-fc.follower.thruster.noise_radius 1.0
+# https://docs.google.com/spreadsheets/d/1PmbRiLaxWfPm8o3WJnG9EudwjCTLcfDGJe1scMyEqao/edit?usp=sharing
+# Best Case 0.0002828427125
+# Expected Case 0.0004242640687
+# Worst Case (Conservative) 0.0008485281374
+
+fc.leader.thruster.noise_sigma 0.0004242640687
+fc.follower.thruster.noise_sigma 0.0004242640687

--- a/config/parameters/fc/base.txt
+++ b/config/parameters/fc/base.txt
@@ -5,3 +5,7 @@ fc.leader.fire_time_near   300
 
 fc.follower.fire_time_far     1800
 fc.follower.fire_time_near    300
+
+# Ideally these would be in an actuators folder...
+fc.leader.thruster.noise_radius 1.0
+fc.follower.thruster.noise_radius 1.0

--- a/include/psim/fc/orbit_controller.yml
+++ b/include/psim/fc/orbit_controller.yml
@@ -15,7 +15,7 @@ params:
       type: Integer
     - name: "fc.{satellite}.fire_time_near"
       type: Integer
-    - name: "fc.{satellite}.thruster.noise_radius"
+    - name: "fc.{satellite}.thruster.noise_sigma"
       type: Real
 adds:
     - name: "fc.{satellite}.cumulative_dv"

--- a/include/psim/fc/orbit_controller.yml
+++ b/include/psim/fc/orbit_controller.yml
@@ -15,6 +15,8 @@ params:
       type: Integer
     - name: "fc.{satellite}.fire_time_near"
       type: Integer
+    - name: "fc.{satellite}.thruster.noise_radius"
+      type: Real
 adds:
     - name: "fc.{satellite}.cumulative_dv"
       type: Real

--- a/src/psim/fc/orbit_controller.cpp
+++ b/src/psim/fc/orbit_controller.cpp
@@ -119,10 +119,7 @@ void OrbitController::step() {
       //get random noise
       Vector3 random_noise = lin::gaussians<Vector3>(_randoms);
 
-      // normalize the random noise
-      random_noise = random_noise / lin::norm(random_noise);
-
-      // apply proper radius scaling
+      // apply radius scaling
       random_noise = random_noise * thruster_noise_sigma;
 
       //add random noise to impulse


### PR DESCRIPTION
# Implemented Noise Radius and Config on Thruster Impulse

This PR adds a spherical gaussian noise on the thruster impulse. The radius of the noise is specified in a config file.

TODO: do the math to specifiy a good noise radius.